### PR TITLE
Filter planner fallback to list items

### DIFF
--- a/backend/orchestrator/service.py
+++ b/backend/orchestrator/service.py
@@ -117,7 +117,14 @@ class OrchestratorService:
         plan_result = planner.run(context)
         plan_steps = list(plan_result.metadata.get("steps", []))
         if not plan_steps:
-            plan_steps = [step.strip("- ") for step in plan_result.content.splitlines() if step]
+            plan_steps = []
+            for line in plan_result.content.splitlines():
+                stripped_line = line.strip()
+                if not stripped_line or not stripped_line.startswith("-"):
+                    continue
+                cleaned_step = stripped_line.lstrip("- ").strip()
+                if cleaned_step:
+                    plan_steps.append(cleaned_step)
 
         state = SessionState(session_id=session_id, goal=goal, plan=plan_steps)
         state.artifacts[planner.name] = plan_result.metadata

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -1,5 +1,6 @@
 """Unit tests for the orchestrator service."""
 
+from backend.agents import AgentResult
 from backend.orchestrator.service import OrchestratorService
 
 
@@ -22,3 +23,28 @@ def test_handle_message_returns_agent_responses() -> None:
     agent_names = [execution.agent for execution in result.results]
     assert "navigator" in agent_names
     assert any("DevOps" in execution.content for execution in result.results)
+
+
+class PlannerWithoutMetadata:
+    """Planner stub that omits structured step metadata."""
+
+    name = "planner"
+
+    def run(self, _) -> AgentResult:  # pragma: no cover - simple stub
+        content = "\n".join(
+            [
+                "Plan Outline:",
+                "- Review requirements",
+                "- Define API endpoints.",
+                "Review findings with stakeholders",
+            ]
+        )
+        return AgentResult(content=content, metadata={})
+
+
+def test_create_plan_fallback_filters_non_list_lines() -> None:
+    service = OrchestratorService(agents={"planner": PlannerWithoutMetadata()})
+
+    session = service.create_plan("Fallback parsing")
+
+    assert session.plan == ["Review requirements", "Define API endpoints."]


### PR DESCRIPTION
## Summary
- update the planner fallback logic to only capture bullet list lines and preserve punctuation
- add a regression test ensuring fallback parsing ignores non-list headers when metadata lacks structured steps

## Testing
- pytest tests/backend/test_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68cd323918cc832a8025dd6b4ae8869b