### PR TITLE
Persist agent conversation history

### DIFF
--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -12,7 +12,7 @@ class AgentContext:
 
     session_id: str
     goal: str | None = None
-    history: List[str] = field(default_factory=list)
+    history: List[Dict[str, str]] = field(default_factory=list)
     artifacts: Dict[str, Any] = field(default_factory=dict)
 
     def with_artifact(self, key: str, value: Any) -> "AgentContext":

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -37,9 +37,14 @@ class AgentExecutionModel(BaseModel):
     metadata: Dict[str, object]
 
 
+class HistoryItemModel(BaseModel):
+    role: str
+    content: str
+
+
 class ChatResponse(BaseModel):
     session_id: str
-    history: List[str]
+    history: List[HistoryItemModel]
     results: List[AgentExecutionModel]
 
 
@@ -76,7 +81,8 @@ def chat(
         AgentExecutionModel(agent=result.agent, content=result.content, metadata=dict(result.metadata))
         for result in run.results
     ]
-    return ChatResponse(session_id=run.session_id, history=list(run.history), results=results)
+    history_items = [HistoryItemModel(role=item.role, content=item.content) for item in run.history]
+    return ChatResponse(session_id=run.session_id, history=history_items, results=results)
 
 
 __all__ = ["app"]

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -53,11 +53,14 @@ function ChatExperience() {
 
     try {
       const response = await sendChatMessage(sessionId, pendingMessage);
-      const agentMessages: Message[] = response.results.map((result) => ({
-        author: result.agent,
-        content: result.content,
+      const conversationMessages: Message[] = response.history.map((entry) => ({
+        author: entry.role === "user" ? "You" : entry.role,
+        content: entry.content,
       }));
-      setMessages((current) => [...current, ...agentMessages]);
+      setMessages((current) => {
+        const planMessages = current.filter((message) => message.author === "Planner");
+        return [...planMessages, ...conversationMessages];
+      });
     } catch (err) {
       setError("Unable to contact orchestrator API");
     } finally {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -4,9 +4,14 @@ export type PlanResponse = {
   plan: string[];
 };
 
+export type ChatHistoryItem = {
+  role: string;
+  content: string;
+};
+
 export type ChatResponse = {
   session_id: string;
-  history: string[];
+  history: ChatHistoryItem[];
   results: { agent: string; content: string; metadata?: Record<string, unknown> }[];
 };
 


### PR DESCRIPTION
## Summary
- store structured history items in the orchestrator session state and persist agent responses between chat turns
- expose the richer history representation through the FastAPI models and frontend types, updating the UI to hydrate from server history
- extend orchestrator tests to confirm agent responses are preserved across sequential chat requests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cd33a9fdf8832ab56ec8cc134db4cd