### PR TITLE
chore: upgrade next.js dependencies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "next": "14.1.0",
+    "next": "14.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "swr": "2.2.0"
@@ -20,7 +20,7 @@
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
     "eslint": "8.56.0",
-    "eslint-config-next": "14.1.0",
+    "eslint-config-next": "14.2.3",
     "typescript": "5.3.3"
   }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -14,8 +18,22 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- bump the Next.js runtime to 14.2.3 and align eslint-config-next to the same release
- accept the Next.js tsconfig adjustments so the Next plugin and generated type files are recognized

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint-config-next)*
- npm run lint
- CI=1 npm run build
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cd3d45b468832a8f8231ad58de9658