### PR TITLE
chore: bump next dependencies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "next": "14.2.3",
+    "next": "14.2.32",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "swr": "2.2.0"
@@ -20,7 +20,7 @@
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
     "eslint": "8.56.0",
-    "eslint-config-next": "14.2.3",
+    "eslint-config-next": "14.2.32",
     "typescript": "5.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- bump Next.js and eslint-config-next to version 14.2.32 to pull in the latest security fixes

## Testing
- [ ] npm install *(fails with 403 Forbidden when contacting https://registry.npmjs.org via the configured proxy)*
- [ ] npm run lint *(blocked because the Next.js CLI is unavailable after the failed install)*
- [ ] npm run build *(blocked because the Next.js CLI is unavailable after the failed install)*
- [ ] npm run typecheck *(blocked because @types/node cannot be resolved after the failed install)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3ff81d08832a855ab05bb7f2e725