### PR TITLE
Implement durable control-plane bootstrap (SQLite) with install script and Docker option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Backend runtime
+DATABASE_URL=sqlite:///./autodev.db
+LLM_PROVIDER=stub
+UVICORN_RELOAD=true
+
+# Frontend runtime
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .venv/
+__pycache__/
+*.py[cod]
+*.db
+frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ This makes the project suitable for:
 
 ## Current repository status
 
-The current codebase provides a functional prototype with:
+The current codebase provides a functional early platform slice with:
 
 - FastAPI backend orchestrator;
+- durable session, run, and message persistence backed by a SQLite store for the first functional stage;
 - agent abstraction layer;
 - stub/fallback LLM integration;
 - simple Next.js chat interface;
-- initial Docker, CI, and Terraform placeholders.
+- local install script, Docker Compose stack, and initial CI/Terraform placeholders.
 
 The documentation in this repository defines the path from prototype to a complete platform.
 
@@ -228,6 +229,24 @@ A production-ready AutoDev Architect release should include:
 ## Development status
 
 This repository is still in the transition from prototype to platform. The new documentation establishes the canonical direction for that transition.
+
+## Running the first durable stage
+
+### Local installation
+
+1. Copy `.env.example` if you want to customize runtime variables.
+2. Run `./scripts/install_dependencies.sh`.
+3. Optionally adjust `DATABASE_URL` (the first functional stage uses SQLite by default).
+4. Start the backend with `source .venv/bin/activate && uvicorn backend.api.main:app --reload`.
+5. Start the frontend with `cd frontend && npm run dev`.
+
+### Docker option
+
+Run `docker compose -f infrastructure/docker-compose.yml up --build`.
+
+This boots:
+- FastAPI backend with a persisted SQLite database volume on `http://localhost:8000`;
+- Next.js frontend on `http://localhost:3000`.
 
 If you are contributing, start with:
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from functools import lru_cache
 from typing import Dict, List
 
@@ -10,10 +11,13 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
 from backend.orchestrator.service import (
+    AgentExecution,
     OrchestratorConfig,
     OrchestratorRun,
     OrchestratorService,
     PlanSession,
+    RunSummary,
+    SessionSummary,
 )
 
 
@@ -25,6 +29,7 @@ class PlanResponse(BaseModel):
     session_id: str
     goal: str
     plan: List[str]
+    status: str
 
 
 class ChatRequest(BaseModel):
@@ -44,8 +49,27 @@ class HistoryItemModel(BaseModel):
 
 
 class ChatResponse(BaseModel):
+    run_id: str
     session_id: str
+    status: str
     history: List[HistoryItemModel]
+    results: List[AgentExecutionModel]
+
+
+class SessionResponse(BaseModel):
+    session_id: str
+    goal: str
+    plan: List[str]
+    status: str
+    history: List[HistoryItemModel]
+
+
+class RunResponse(BaseModel):
+    run_id: str
+    session_id: str
+    status: str
+    trigger_message: str
+    created_at: str
     results: List[AgentExecutionModel]
 
 
@@ -54,7 +78,13 @@ def get_orchestrator() -> OrchestratorService:
     return OrchestratorService(config=OrchestratorConfig())
 
 
-app = FastAPI(title="AutoDev Orchestrator", version="0.1.0")
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    get_orchestrator()
+    yield
+
+
+app = FastAPI(title="AutoDev Orchestrator", version="0.2.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
@@ -79,6 +109,53 @@ def create_plan(request: PlanRequest, orchestrator: OrchestratorService = Depend
     return PlanResponse(**plan_session.to_dict())
 
 
+@app.get("/sessions", response_model=List[SessionResponse], tags=["sessions"])
+def list_sessions(orchestrator: OrchestratorService = Depends(get_orchestrator)) -> List[SessionResponse]:
+    sessions = orchestrator.list_sessions()
+    return [
+        SessionResponse(
+            session_id=session.session_id,
+            goal=session.goal,
+            plan=session.plan,
+            status=session.status,
+            history=[HistoryItemModel(role=item.role, content=item.content) for item in session.history],
+        )
+        for session in sessions
+    ]
+
+
+@app.get("/sessions/{session_id}", response_model=SessionResponse, tags=["sessions"])
+def get_session(
+    session_id: str,
+    orchestrator: OrchestratorService = Depends(get_orchestrator),
+) -> SessionResponse:
+    try:
+        session: SessionSummary = orchestrator.get_session(session_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return SessionResponse(
+        session_id=session.session_id,
+        goal=session.goal,
+        plan=session.plan,
+        status=session.status,
+        history=[HistoryItemModel(role=item.role, content=item.content) for item in session.history],
+    )
+
+
+@app.get("/sessions/{session_id}/runs", response_model=List[RunResponse], tags=["runs"])
+def list_runs(
+    session_id: str,
+    orchestrator: OrchestratorService = Depends(get_orchestrator),
+) -> List[RunResponse]:
+    try:
+        runs = orchestrator.list_runs(session_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return [_to_run_response(run) for run in runs]
+
+
 @app.post("/chat", response_model=ChatResponse, tags=["chat"])
 def chat(
     request: ChatRequest,
@@ -89,12 +166,28 @@ def chat(
     except KeyError as exc:  # pragma: no cover - exercised via tests
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
-    results = [
-        AgentExecutionModel(agent=result.agent, content=result.content, metadata=dict(result.metadata))
-        for result in run.results
-    ]
-    history_items = [HistoryItemModel(role=item.role, content=item.content) for item in run.history]
-    return ChatResponse(session_id=run.session_id, history=history_items, results=results)
+    return ChatResponse(
+        run_id=run.run_id,
+        session_id=run.session_id,
+        status=run.status,
+        history=[HistoryItemModel(role=item.role, content=item.content) for item in run.history],
+        results=[_to_agent_execution_model(result) for result in run.results],
+    )
+
+
+def _to_run_response(run: RunSummary) -> RunResponse:
+    return RunResponse(
+        run_id=run.run_id,
+        session_id=run.session_id,
+        status=run.status,
+        trigger_message=run.trigger_message,
+        created_at=run.created_at,
+        results=[_to_agent_execution_model(result) for result in run.results],
+    )
+
+
+def _to_agent_execution_model(result: AgentExecution) -> AgentExecutionModel:
+    return AgentExecutionModel(agent=result.agent, content=result.content, metadata=dict(result.metadata))
 
 
 __all__ = ["app"]

--- a/backend/orchestrator/service.py
+++ b/backend/orchestrator/service.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, TypedDict
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, TypedDict
 from uuid import uuid4
 
 from langgraph.graph import END, StateGraph
@@ -20,6 +20,7 @@ from backend.agents import (
     PlannerAgent,
     ValidatorAgent,
 )
+from backend.persistence import DurableStore, get_store
 
 
 @dataclass(slots=True)
@@ -31,17 +32,6 @@ class HistoryItem:
 
     def to_dict(self) -> Dict[str, str]:
         return {"role": self.role, "content": self.content}
-
-
-@dataclass(slots=True)
-class SessionState:
-    """In-memory representation of an orchestration session."""
-
-    session_id: str
-    goal: str
-    plan: List[str]
-    history: List[HistoryItem] = field(default_factory=list)
-    artifacts: Dict[str, Mapping[str, Any]] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -57,13 +47,17 @@ class AgentExecution:
 class OrchestratorRun:
     """Aggregate response returned to the API layer."""
 
+    run_id: str
     session_id: str
+    status: str
     history: List[HistoryItem]
     results: List[AgentExecution]
 
     def to_dict(self) -> Dict[str, Any]:
         return {
+            "run_id": self.run_id,
             "session_id": self.session_id,
+            "status": self.status,
             "history": [item.to_dict() for item in self.history],
             "results": [
                 {"agent": result.agent, "content": result.content, "metadata": dict(result.metadata)}
@@ -79,9 +73,38 @@ class PlanSession:
     session_id: str
     goal: str
     plan: List[str]
+    status: str = "drafting_plan"
 
     def to_dict(self) -> Dict[str, Any]:
-        return {"session_id": self.session_id, "goal": self.goal, "plan": list(self.plan)}
+        return {
+            "session_id": self.session_id,
+            "goal": self.goal,
+            "plan": list(self.plan),
+            "status": self.status,
+        }
+
+
+@dataclass(slots=True)
+class SessionSummary:
+    """Session details exposed by the API."""
+
+    session_id: str
+    goal: str
+    plan: List[str]
+    status: str
+    history: List[HistoryItem]
+
+
+@dataclass(slots=True)
+class RunSummary:
+    """Stored run details for history endpoints."""
+
+    run_id: str
+    session_id: str
+    status: str
+    trigger_message: str
+    created_at: str
+    results: List[AgentExecution]
 
 
 @dataclass(slots=True)
@@ -102,22 +125,23 @@ class AgentGraphState(TypedDict):
     """State propagated through the LangGraph workflow."""
 
     context: AgentContext
-    results: List["AgentExecution"]
+    results: List[AgentExecution]
 
 
 class OrchestratorService:
-    """Coordinate agent execution for a session."""
+    """Coordinate agent execution for a durable session."""
 
     def __init__(
         self,
         config: OrchestratorConfig | None = None,
         agents: Mapping[str, Agent] | None = None,
+        store: DurableStore | None = None,
     ) -> None:
         self._config = config or OrchestratorConfig()
         self._agents = self._build_default_agents()
         if agents:
             self._agents.update(agents)
-        self._sessions: Dict[str, SessionState] = {}
+        self._store = store or get_store()
         self._graph = self._compile_graph()
 
     def create_plan(self, goal: str) -> PlanSession:
@@ -125,50 +149,143 @@ class OrchestratorService:
         session_id = str(uuid4())
         context = AgentContext(session_id=session_id, goal=goal)
         plan_result = planner.run(context)
-        plan_steps = list(plan_result.metadata.get("steps", []))
-        if not plan_steps:
-            plan_steps = []
-            for line in plan_result.content.splitlines():
-                stripped_line = line.strip()
-                if not stripped_line or not stripped_line.startswith("-"):
-                    continue
-                cleaned_step = stripped_line.lstrip("- ").strip()
-                if cleaned_step:
-                    plan_steps.append(cleaned_step)
+        plan_steps = self._extract_plan_steps(plan_result)
+        status = "awaiting_input"
 
-        state = SessionState(session_id=session_id, goal=goal, plan=plan_steps)
-        state.artifacts[planner.name] = plan_result.metadata
-        self._sessions[session_id] = state
-        return PlanSession(session_id=session_id, goal=goal, plan=plan_steps)
+        self._store.create_session(
+            session_id=session_id,
+            goal=goal,
+            plan=plan_steps,
+            artifacts={planner.name: dict(plan_result.metadata)},
+        )
+
+        return PlanSession(session_id=session_id, goal=goal, plan=plan_steps, status=status)
 
     def handle_message(self, session_id: str, message: str) -> OrchestratorRun:
-        state = self._sessions.get(session_id)
-        if state is None:
+        session_record = self._store.get_session(session_id)
+        if session_record is None:
             raise KeyError(f"Unknown session_id: {session_id}")
 
+        history = [
+            HistoryItem(role=record["role"], content=record["content"])
+            for record in self._store.list_messages(session_id)
+        ]
         user_entry = HistoryItem(role="user", content=message)
         context = AgentContext(
             session_id=session_id,
-            goal=state.goal,
-            history=[entry.to_dict() for entry in state.history] + [user_entry.to_dict()],
-            artifacts={name: dict(meta) for name, meta in state.artifacts.items()},
+            goal=session_record["goal"],
+            history=[item.to_dict() for item in history] + [user_entry.to_dict()],
+            artifacts=dict(session_record["artifacts"] or {}),
         )
 
         initial_state: AgentGraphState = {"context": context, "results": []}
         final_state = self._graph.invoke(initial_state)
         final_context = final_state["context"]
         results = list(final_state["results"])
+        run_id = str(uuid4())
 
-        state.history = [HistoryItem(**item) for item in final_context.history]
-        state.artifacts = self._clone_artifacts(final_context.artifacts)
+        self._store.create_run(
+            run_id=run_id,
+            session_id=session_id,
+            status="completed",
+            trigger_message=message,
+            results=[
+                {
+                    "agent": result.agent,
+                    "content": result.content,
+                    "metadata": dict(result.metadata),
+                }
+                for result in results
+            ],
+        )
 
-        return OrchestratorRun(session_id=session_id, history=list(state.history), results=results)
+        next_history = [HistoryItem(**item) for item in final_context.history]
+        self._store.append_messages(
+            session_id,
+            run_id,
+            [item.to_dict() for item in next_history],
+        )
+        self._store.update_session_artifacts(session_id, self._clone_artifacts(final_context.artifacts))
+
+        return OrchestratorRun(
+            run_id=run_id,
+            session_id=session_id,
+            status="completed",
+            history=next_history,
+            results=results,
+        )
 
     def get_plan(self, session_id: str) -> PlanSession:
-        state = self._sessions.get(session_id)
+        state = self._store.get_session(session_id)
         if state is None:
             raise KeyError(f"Unknown session_id: {session_id}")
-        return PlanSession(session_id=state.session_id, goal=state.goal, plan=list(state.plan))
+        return PlanSession(
+            session_id=state["id"],
+            goal=state["goal"],
+            plan=list(state["plan"] or []),
+            status="awaiting_input",
+        )
+
+    def list_sessions(self) -> List[SessionSummary]:
+        return [self._build_session_summary(record) for record in self._store.list_sessions()]
+
+    def get_session(self, session_id: str) -> SessionSummary:
+        record = self._store.get_session(session_id)
+        if record is None:
+            raise KeyError(f"Unknown session_id: {session_id}")
+        return self._build_session_summary(record)
+
+    def list_runs(self, session_id: str) -> List[RunSummary]:
+        session_record = self._store.get_session(session_id)
+        if session_record is None:
+            raise KeyError(f"Unknown session_id: {session_id}")
+        return [self._build_run_summary(record) for record in self._store.list_runs(session_id)]
+
+    def _build_session_summary(self, record: dict[str, Any]) -> SessionSummary:
+        history = [
+            HistoryItem(role=item["role"], content=item["content"])
+            for item in self._store.list_messages(record["id"])
+        ]
+        return SessionSummary(
+            session_id=record["id"],
+            goal=record["goal"],
+            plan=list(record["plan"] or []),
+            status="awaiting_input",
+            history=history,
+        )
+
+    def _build_run_summary(self, record: dict[str, Any]) -> RunSummary:
+        results = [
+            AgentExecution(
+                agent=item.get("agent", "unknown"),
+                content=item.get("content", ""),
+                metadata=item.get("metadata", {}),
+            )
+            for item in (record["results"] or [])
+        ]
+        return RunSummary(
+            run_id=record["id"],
+            session_id=record["session_id"],
+            status=record["status"],
+            trigger_message=record["trigger_message"],
+            created_at=record["created_at"],
+            results=results,
+        )
+
+    def _extract_plan_steps(self, plan_result: AgentResult) -> List[str]:
+        plan_steps = list(plan_result.metadata.get("steps", []))
+        if plan_steps:
+            return plan_steps
+
+        extracted_steps: List[str] = []
+        for line in plan_result.content.splitlines():
+            stripped_line = line.strip()
+            if not stripped_line or not stripped_line.startswith("-"):
+                continue
+            cleaned_step = stripped_line.lstrip("- ").strip()
+            if cleaned_step:
+                extracted_steps.append(cleaned_step)
+        return extracted_steps
 
     def _require_agent(self, name: str) -> Agent:
         if name not in self._agents:
@@ -219,22 +336,5 @@ class OrchestratorService:
 
         return node
 
-    def _clone_artifacts(self, artifacts: Mapping[str, Any]) -> Dict[str, Mapping[str, Any]]:
-        cloned: Dict[str, Mapping[str, Any]] = {}
-        for name, value in artifacts.items():
-            if isinstance(value, MutableMapping):
-                cloned[name] = dict(value)
-            else:
-                cloned[name] = value
-        return cloned
-
-
-__all__ = [
-    "AgentExecution",
-    "HistoryItem",
-    "OrchestratorConfig",
-    "OrchestratorRun",
-    "OrchestratorService",
-    "PlanSession",
-    "SessionState",
-]
+    def _clone_artifacts(self, artifacts: Mapping[str, Mapping[str, Any]]) -> Dict[str, Dict[str, Any]]:
+        return {name: dict(meta) for name, meta in artifacts.items()}

--- a/backend/persistence/__init__.py
+++ b/backend/persistence/__init__.py
@@ -1,0 +1,5 @@
+"""Persistence helpers for durable orchestration state."""
+
+from .database import DurableStore, get_store, reset_store_cache
+
+__all__ = ["DurableStore", "get_store", "reset_store_cache"]

--- a/backend/persistence/database.py
+++ b/backend/persistence/database.py
@@ -1,0 +1,223 @@
+"""SQLite-backed durable state for the initial control-plane slice."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable
+
+
+DEFAULT_DATABASE_URL = "sqlite:///./autodev.db"
+
+
+@dataclass(slots=True)
+class DurableStore:
+    """Repository wrapper for durable orchestration state."""
+
+    database_url: str
+    _database_path: Path = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._database_path = self._resolve_database_path(self.database_url)
+        self._database_path.parent.mkdir(parents=True, exist_ok=True)
+        self.create_tables()
+
+    def create_tables(self) -> None:
+        with self.connect() as connection:
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    id TEXT PRIMARY KEY,
+                    goal TEXT NOT NULL,
+                    plan_json TEXT NOT NULL,
+                    artifacts_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+
+                CREATE TABLE IF NOT EXISTS runs (
+                    id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    trigger_message TEXT NOT NULL,
+                    results_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    completed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY(session_id) REFERENCES sessions(id)
+                );
+
+                CREATE TABLE IF NOT EXISTS messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL,
+                    run_id TEXT,
+                    sequence INTEGER NOT NULL,
+                    role TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY(session_id) REFERENCES sessions(id),
+                    FOREIGN KEY(run_id) REFERENCES runs(id)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_runs_session_id ON runs(session_id);
+                CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, sequence);
+                """
+            )
+            connection.commit()
+
+    def connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._database_path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def create_session(
+        self,
+        *,
+        session_id: str,
+        goal: str,
+        plan: list[str],
+        artifacts: dict[str, Any],
+    ) -> None:
+        with self.connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO sessions (id, goal, plan_json, artifacts_json)
+                VALUES (?, ?, ?, ?)
+                """,
+                (session_id, goal, json.dumps(plan), json.dumps(artifacts)),
+            )
+            connection.commit()
+
+    def get_session(self, session_id: str) -> dict[str, Any] | None:
+        with self.connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+        return self._decode_session(row)
+
+    def list_sessions(self) -> list[dict[str, Any]]:
+        with self.connect() as connection:
+            rows = connection.execute(
+                "SELECT * FROM sessions ORDER BY created_at DESC"
+            ).fetchall()
+        return [self._decode_session(row) for row in rows]
+
+    def update_session_artifacts(self, session_id: str, artifacts: dict[str, Any]) -> None:
+        with self.connect() as connection:
+            connection.execute(
+                """
+                UPDATE sessions
+                SET artifacts_json = ?, updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """,
+                (json.dumps(artifacts), session_id),
+            )
+            connection.commit()
+
+    def create_run(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        status: str,
+        trigger_message: str,
+        results: list[dict[str, Any]],
+    ) -> None:
+        with self.connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO runs (id, session_id, status, trigger_message, results_json)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (run_id, session_id, status, trigger_message, json.dumps(results)),
+            )
+            connection.commit()
+
+    def list_runs(self, session_id: str) -> list[dict[str, Any]]:
+        with self.connect() as connection:
+            rows = connection.execute(
+                "SELECT * FROM runs WHERE session_id = ? ORDER BY rowid DESC",
+                (session_id,),
+            ).fetchall()
+        return [self._decode_run(row) for row in rows]
+
+    def list_messages(self, session_id: str) -> list[dict[str, Any]]:
+        with self.connect() as connection:
+            rows = connection.execute(
+                "SELECT * FROM messages WHERE session_id = ? ORDER BY sequence ASC",
+                (session_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def append_messages(self, session_id: str, run_id: str, history: Iterable[dict[str, str]]) -> None:
+        existing_messages = self.list_messages(session_id)
+        start_sequence = len(existing_messages)
+        new_messages = list(history)[start_sequence:]
+        if not new_messages:
+            return
+
+        with self.connect() as connection:
+            connection.executemany(
+                """
+                INSERT INTO messages (session_id, run_id, sequence, role, content)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                [
+                    (session_id, run_id, offset, item["role"], item["content"])
+                    for offset, item in enumerate(new_messages, start=start_sequence)
+                ],
+            )
+            connection.commit()
+
+    def _decode_session(self, row: sqlite3.Row | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "goal": row["goal"],
+            "plan": json.loads(row["plan_json"]),
+            "artifacts": json.loads(row["artifacts_json"]),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    def _decode_run(self, row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "session_id": row["session_id"],
+            "status": row["status"],
+            "trigger_message": row["trigger_message"],
+            "results": json.loads(row["results_json"]),
+            "created_at": row["created_at"],
+            "completed_at": row["completed_at"],
+        }
+
+    def _resolve_database_path(self, database_url: str) -> Path:
+        normalized = database_url.strip() or DEFAULT_DATABASE_URL
+        if normalized.startswith("sqlite:///"):
+            path = normalized.removeprefix("sqlite:///")
+            return Path(path).expanduser().resolve()
+        if normalized.startswith("sqlite://"):
+            path = normalized.removeprefix("sqlite://")
+            return Path(path).expanduser().resolve()
+        raise ValueError(
+            "The initial durable slice currently supports only sqlite DATABASE_URL values. "
+            "Use a URL like sqlite:///./autodev.db."
+        )
+
+
+@lru_cache(maxsize=1)
+def get_store() -> DurableStore:
+    """Return a cached durable store."""
+
+    return DurableStore(os.getenv("DATABASE_URL", DEFAULT_DATABASE_URL))
+
+
+def reset_store_cache() -> None:
+    """Clear the cached store, mainly for tests."""
+
+    get_store.cache_clear()

--- a/docs/implementation/implementation_strategy.md
+++ b/docs/implementation/implementation_strategy.md
@@ -37,6 +37,12 @@ Do not attempt to build every promised feature simultaneously. Instead, convert 
 ### Notes
 This phase creates the foundation needed for all later features.
 
+Current functional slice in this repository:
+- durable session, run, and message persistence through a SQLite bootstrap store;
+- resumable history across service restarts;
+- API endpoints for run creation, session lookup, and run history;
+- a clean path remains open for PostgreSQL/Redis in the next infrastructure slice.
+
 ---
 
 ## Phase 2: Explicit workflow engine

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,6 +28,11 @@ Goals:
 - structured agent outputs
 - improved API contracts
 
+Current implementation status:
+- durable sessions, runs, and message history are now persisted via a SQLite-backed bootstrap store;
+- API endpoints expose session and run history for inspection;
+- PostgreSQL and Redis-backed async execution remain pending in the next slices.
+
 Success criteria:
 - sessions survive restart
 - runs can be resumed and inspected

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -6,9 +6,14 @@ services:
       context: ..
       dockerfile: infrastructure/docker/backend.Dockerfile
     environment:
-      - UVICORN_RELOAD=false
+      DATABASE_URL: sqlite:////data/autodev.db
+      LLM_PROVIDER: stub
+      UVICORN_RELOAD: "false"
     ports:
       - "8000:8000"
+    volumes:
+      - autodev_data:/data
+
   frontend:
     image: node:20
     working_dir: /app
@@ -16,8 +21,11 @@ services:
     volumes:
       - ../frontend:/app
     environment:
-      - NEXT_PUBLIC_API_URL=http://backend:8000
+      NEXT_PUBLIC_API_URL: http://localhost:8000
     ports:
       - "3000:3000"
     depends_on:
       - backend
+
+volumes:
+  autodev_data:

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+VENV_DIR="${VENV_DIR:-$ROOT_DIR/.venv}"
+NODE_BIN="${NODE_BIN:-npm}"
+
+printf '\n[1/4] Creating Python virtual environment at %s\n' "$VENV_DIR"
+"$PYTHON_BIN" -m venv "$VENV_DIR"
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+
+printf '\n[2/4] Installing backend dependencies\n'
+pip install --upgrade pip
+pip install -r "$ROOT_DIR/backend/requirements.txt"
+
+printf '\n[3/4] Installing frontend dependencies\n'
+cd "$ROOT_DIR/frontend"
+"$NODE_BIN" install
+
+printf '\n[4/4] Done\n'
+printf 'Backend venv: %s\n' "$VENV_DIR"
+printf 'Run backend with: source %s/bin/activate && uvicorn backend.api.main:app --reload\n' "$VENV_DIR"
+printf 'Run frontend with: cd %s/frontend && %s run dev\n' "$ROOT_DIR" "$NODE_BIN"

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -1,0 +1,60 @@
+"""API integration tests for durable orchestration endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api.main import app, get_orchestrator
+from backend.orchestrator.service import OrchestratorService
+from backend.persistence.database import DurableStore, reset_store_cache
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    database_path = tmp_path / "api-test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{database_path}")
+    reset_store_cache()
+    get_orchestrator.cache_clear()
+    app.dependency_overrides[get_orchestrator] = lambda: OrchestratorService(
+        store=DurableStore(f"sqlite:///{database_path}")
+    )
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+    get_orchestrator.cache_clear()
+    reset_store_cache()
+
+
+def test_session_and_run_endpoints(client: TestClient) -> None:
+    plan_response = client.post("/plan", json={"goal": "Ship durable control plane"})
+    assert plan_response.status_code == 200
+    plan_payload = plan_response.json()
+    assert plan_payload["status"] == "awaiting_input"
+
+    session_id = plan_payload["session_id"]
+
+    chat_response = client.post(
+        "/chat",
+        json={"session_id": session_id, "message": "Execute the first iteration"},
+    )
+    assert chat_response.status_code == 200
+    chat_payload = chat_response.json()
+    assert chat_payload["status"] == "completed"
+    assert chat_payload["run_id"]
+
+    session_response = client.get(f"/sessions/{session_id}")
+    assert session_response.status_code == 200
+    assert len(session_response.json()["history"]) >= len(chat_payload["history"])
+
+    sessions_response = client.get("/sessions")
+    assert sessions_response.status_code == 200
+    assert sessions_response.json()[0]["session_id"] == session_id
+
+    runs_response = client.get(f"/sessions/{session_id}/runs")
+    assert runs_response.status_code == 200
+    runs_payload = runs_response.json()
+    assert len(runs_payload) == 1
+    assert runs_payload[0]["trigger_message"] == "Execute the first iteration"

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -1,24 +1,42 @@
 """Unit tests for the orchestrator service."""
 
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
 from backend.agents import AgentResult
 from backend.orchestrator.service import OrchestratorService
+from backend.persistence.database import DurableStore, reset_store_cache
 
 
-def test_create_plan_generates_steps() -> None:
-    service = OrchestratorService()
-    session = service.create_plan("Implement orchestrator")
+@pytest.fixture()
+def orchestrator_service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> OrchestratorService:
+    database_path = tmp_path / "autodev-test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{database_path}")
+    reset_store_cache()
+    service = OrchestratorService(store=DurableStore(f"sqlite:///{database_path}"))
+    yield service
+    reset_store_cache()
+
+
+def test_create_plan_generates_steps(orchestrator_service: OrchestratorService) -> None:
+    session = orchestrator_service.create_plan("Implement orchestrator")
 
     assert session.session_id
     assert session.plan
     assert "Implement" in session.plan[0]
+    assert session.status == "awaiting_input"
 
 
-def test_handle_message_returns_agent_responses() -> None:
-    service = OrchestratorService()
-    session = service.create_plan("Ship MVP")
+def test_handle_message_returns_agent_responses(orchestrator_service: OrchestratorService) -> None:
+    session = orchestrator_service.create_plan("Ship MVP")
 
-    result = service.handle_message(session.session_id, "Start execution")
+    result = orchestrator_service.handle_message(session.session_id, "Start execution")
 
+    assert result.run_id
+    assert result.status == "completed"
     assert result.session_id == session.session_id
     agent_names = [execution.agent for execution in result.results]
     assert "navigator" in agent_names
@@ -28,14 +46,18 @@ def test_handle_message_returns_agent_responses() -> None:
     assert all(entry.content for entry in result.history)
 
 
-def test_history_persists_across_messages() -> None:
-    service = OrchestratorService()
-    session = service.create_plan("Track conversation")
+def test_history_persists_across_service_instances(
+    orchestrator_service: OrchestratorService,
+    tmp_path: Path,
+) -> None:
+    session = orchestrator_service.create_plan("Track conversation")
 
-    first_run = service.handle_message(session.session_id, "Initial question")
+    first_run = orchestrator_service.handle_message(session.session_id, "Initial question")
     assert any(entry.role != "user" for entry in first_run.history)
 
-    second_run = service.handle_message(session.session_id, "Follow up")
+    database_path = tmp_path / "autodev-test.db"
+    reloaded_service = OrchestratorService(store=DurableStore(f"sqlite:///{database_path}"))
+    second_run = reloaded_service.handle_message(session.session_id, "Follow up")
 
     assert len(second_run.history) > len(first_run.history)
     assert [entry.role for entry in first_run.history] == [
@@ -44,6 +66,19 @@ def test_history_persists_across_messages() -> None:
     assert [entry.content for entry in first_run.history] == [
         entry.content for entry in second_run.history[: len(first_run.history)]
     ]
+
+
+def test_run_history_is_queryable(orchestrator_service: OrchestratorService) -> None:
+    session = orchestrator_service.create_plan("Persist runs")
+    orchestrator_service.handle_message(session.session_id, "Run once")
+    orchestrator_service.handle_message(session.session_id, "Run twice")
+
+    runs = orchestrator_service.list_runs(session.session_id)
+
+    assert len(runs) == 2
+    assert runs[0].trigger_message == "Run twice"
+    assert runs[1].trigger_message == "Run once"
+    assert runs[0].results
 
 
 class PlannerWithoutMetadata:
@@ -63,8 +98,11 @@ class PlannerWithoutMetadata:
         return AgentResult(content=content, metadata={})
 
 
-def test_create_plan_fallback_filters_non_list_lines() -> None:
-    service = OrchestratorService(agents={"planner": PlannerWithoutMetadata()})
+def test_create_plan_fallback_filters_non_list_lines(orchestrator_service: OrchestratorService) -> None:
+    service = OrchestratorService(
+        agents={"planner": PlannerWithoutMetadata()},
+        store=orchestrator_service._store,
+    )
 
     session = service.create_plan("Fallback parsing")
 


### PR DESCRIPTION
### Motivation

- Provide the first functional vertical slice from the roadmap: a durable control plane that persists sessions, runs, message history, and artifacts so state survives process restarts. 

### Description

- Introduce a lightweight persistence layer (`backend/persistence/database.py`, `backend/persistence/__init__.py`) implementing a SQLite-backed `DurableStore` for sessions, runs, messages, and artifacts. 
- Replace the in-memory session store in the orchestrator with the durable store and wire persistence into plan creation, message handling, run storage, message append, and artifacts update (`backend/orchestrator/service.py`).
- Extend the API to expose richer models and new endpoints for listing sessions, fetching a session, and listing runs for a session, and return `run_id`/`status` on `/chat` and `status` on `/plan` (`backend/api/main.py`).
- Add local installer script and environment example: `scripts/install_dependencies.sh` and `.env.example` for bootstrapping a Python venv, backend and frontend dependencies. 
- Add a Docker Compose configuration that supports a persisted backend data volume for the SQLite bootstrap store (`infrastructure/docker-compose.yml`).
- Update documentation to reflect the new durable slice and provide local and Docker run instructions (`README.md`, `docs/roadmap.md`, `docs/implementation/implementation_strategy.md`).
- Add tests that exercise persistence and the new API endpoints (`tests/backend/test_api.py`, updated `tests/backend/test_orchestrator.py`).
- Add `.gitignore` entries and small housekeeping changes.

### Testing

- Ran unit and integration tests with `pytest` and all tests passed (6 passed).  
- Compiled backend with `python -m compileall backend` which succeeded.  
- Validated install script syntax with `bash -n scripts/install_dependencies.sh` which passed.  
- Docker Compose config cannot be executed in this environment because `docker` is not available, but `docker compose -f infrastructure/docker-compose.yml config` was documented as a recommended validation step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfd80c319c832ab0abd3fbe9f5df56)