### PR TITLE
Implement workflow state tracking slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The current codebase provides a functional early platform slice with:
 
 - FastAPI backend orchestrator;
 - durable session, run, and message persistence backed by a SQLite store for the first functional stage;
+- explicit run typing plus persisted workflow-step history for each execution;
 - agent abstraction layer;
 - stub/fallback LLM integration;
 - simple Next.js chat interface;
@@ -217,7 +218,7 @@ A production-ready AutoDev Architect release should include:
 
 1. Replace in-memory state with PostgreSQL persistence.
 2. Add Redis-backed async execution.
-3. Introduce an explicit run state machine and approval model.
+3. Expand the new workflow-state slice into a full explicit run state machine and approval model.
 4. Implement repository indexing using tree-sitter and pgvector.
 5. Generate and validate patches in isolated workspaces.
 6. Expand the UI from chat demo to execution control center.
@@ -255,4 +256,3 @@ If you are contributing, start with:
 3. `docs/architecture/target_architecture.md`
 4. `docs/implementation/implementation_strategy.md`
 5. `AGENTS.md`
-

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -16,6 +16,7 @@ from backend.orchestrator.service import (
     OrchestratorRun,
     OrchestratorService,
     PlanSession,
+    RunStep,
     RunSummary,
     SessionSummary,
 )
@@ -43,6 +44,15 @@ class AgentExecutionModel(BaseModel):
     metadata: Dict[str, object]
 
 
+class RunStepModel(BaseModel):
+    step_key: str
+    agent: str
+    status: str
+    started_at: str
+    completed_at: str
+    attempt: int
+
+
 class HistoryItemModel(BaseModel):
     role: str
     content: str
@@ -52,8 +62,11 @@ class ChatResponse(BaseModel):
     run_id: str
     session_id: str
     status: str
+    run_type: str
+    current_state: str
     history: List[HistoryItemModel]
     results: List[AgentExecutionModel]
+    steps: List[RunStepModel]
 
 
 class SessionResponse(BaseModel):
@@ -68,9 +81,12 @@ class RunResponse(BaseModel):
     run_id: str
     session_id: str
     status: str
+    run_type: str
+    current_state: str
     trigger_message: str
     created_at: str
     results: List[AgentExecutionModel]
+    steps: List[RunStepModel]
 
 
 @lru_cache(maxsize=1)
@@ -170,8 +186,11 @@ def chat(
         run_id=run.run_id,
         session_id=run.session_id,
         status=run.status,
+        run_type=run.run_type,
+        current_state=run.current_state,
         history=[HistoryItemModel(role=item.role, content=item.content) for item in run.history],
         results=[_to_agent_execution_model(result) for result in run.results],
+        steps=[_to_run_step_model(step) for step in run.steps],
     )
 
 
@@ -180,14 +199,28 @@ def _to_run_response(run: RunSummary) -> RunResponse:
         run_id=run.run_id,
         session_id=run.session_id,
         status=run.status,
+        run_type=run.run_type,
+        current_state=run.current_state,
         trigger_message=run.trigger_message,
         created_at=run.created_at,
         results=[_to_agent_execution_model(result) for result in run.results],
+        steps=[_to_run_step_model(step) for step in run.steps],
     )
 
 
 def _to_agent_execution_model(result: AgentExecution) -> AgentExecutionModel:
     return AgentExecutionModel(agent=result.agent, content=result.content, metadata=dict(result.metadata))
+
+
+def _to_run_step_model(step: RunStep) -> RunStepModel:
+    return RunStepModel(
+        step_key=step.step_key,
+        agent=step.agent,
+        status=step.status,
+        started_at=step.started_at,
+        completed_at=step.completed_at,
+        attempt=step.attempt,
+    )
 
 
 __all__ = ["app"]

--- a/backend/orchestrator/service.py
+++ b/backend/orchestrator/service.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
 from typing import Any, Dict, Iterable, List, Mapping, TypedDict
 from uuid import uuid4
 
@@ -43,6 +45,52 @@ class AgentExecution:
     metadata: Mapping[str, Any]
 
 
+class RunType(StrEnum):
+    """Supported workflow types for orchestrator runs."""
+
+    GREENFIELD_BOOTSTRAP = "greenfield_bootstrap"
+    EXISTING_REPO_CHANGE = "existing_repo_change"
+    DOCUMENTATION_UPDATE = "documentation_update"
+    DEVOPS_CHANGE = "devops_change"
+    VALIDATION_ONLY = "validation_only"
+
+
+class RunStatus(StrEnum):
+    """Top-level states used by the explicit workflow engine slice."""
+
+    AWAITING_INPUT = "awaiting_input"
+    RUNNING = "running"
+    COMPLETED = "completed"
+
+
+class StepStatus(StrEnum):
+    """Execution status for an individual workflow step."""
+
+    COMPLETED = "completed"
+
+
+@dataclass(slots=True)
+class RunStep:
+    """Represents a completed step within a run."""
+
+    step_key: str
+    agent: str
+    status: str
+    started_at: str
+    completed_at: str
+    attempt: int = 1
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "step_key": self.step_key,
+            "agent": self.agent,
+            "status": self.status,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "attempt": self.attempt,
+        }
+
+
 @dataclass(slots=True)
 class OrchestratorRun:
     """Aggregate response returned to the API layer."""
@@ -50,19 +98,25 @@ class OrchestratorRun:
     run_id: str
     session_id: str
     status: str
+    run_type: str
+    current_state: str
     history: List[HistoryItem]
     results: List[AgentExecution]
+    steps: List[RunStep]
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "run_id": self.run_id,
             "session_id": self.session_id,
             "status": self.status,
+            "run_type": self.run_type,
+            "current_state": self.current_state,
             "history": [item.to_dict() for item in self.history],
             "results": [
                 {"agent": result.agent, "content": result.content, "metadata": dict(result.metadata)}
                 for result in self.results
             ],
+            "steps": [step.to_dict() for step in self.steps],
         }
 
 
@@ -73,7 +127,7 @@ class PlanSession:
     session_id: str
     goal: str
     plan: List[str]
-    status: str = "drafting_plan"
+    status: str = RunStatus.AWAITING_INPUT
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -102,9 +156,12 @@ class RunSummary:
     run_id: str
     session_id: str
     status: str
+    run_type: str
+    current_state: str
     trigger_message: str
     created_at: str
     results: List[AgentExecution]
+    steps: List[RunStep]
 
 
 @dataclass(slots=True)
@@ -126,6 +183,8 @@ class AgentGraphState(TypedDict):
 
     context: AgentContext
     results: List[AgentExecution]
+    steps: List[RunStep]
+    current_state: str
 
 
 class OrchestratorService:
@@ -150,7 +209,7 @@ class OrchestratorService:
         context = AgentContext(session_id=session_id, goal=goal)
         plan_result = planner.run(context)
         plan_steps = self._extract_plan_steps(plan_result)
-        status = "awaiting_input"
+        status = RunStatus.AWAITING_INPUT
 
         self._store.create_session(
             session_id=session_id,
@@ -166,6 +225,20 @@ class OrchestratorService:
         if session_record is None:
             raise KeyError(f"Unknown session_id: {session_id}")
 
+        run_type = self._infer_run_type(goal=session_record["goal"], message=message)
+        run_id = str(uuid4())
+
+        self._store.create_run(
+            run_id=run_id,
+            session_id=session_id,
+            status=RunStatus.RUNNING,
+            run_type=run_type,
+            current_state="starting",
+            trigger_message=message,
+            results=[],
+            steps=[],
+        )
+
         history = [
             HistoryItem(role=record["role"], content=record["content"])
             for record in self._store.list_messages(session_id)
@@ -178,17 +251,22 @@ class OrchestratorService:
             artifacts=dict(session_record["artifacts"] or {}),
         )
 
-        initial_state: AgentGraphState = {"context": context, "results": []}
+        initial_state: AgentGraphState = {
+            "context": context,
+            "results": [],
+            "steps": [],
+            "current_state": "starting",
+        }
         final_state = self._graph.invoke(initial_state)
         final_context = final_state["context"]
         results = list(final_state["results"])
-        run_id = str(uuid4())
+        steps = list(final_state["steps"])
+        current_state = final_state["current_state"]
 
-        self._store.create_run(
+        self._store.update_run(
             run_id=run_id,
-            session_id=session_id,
-            status="completed",
-            trigger_message=message,
+            status=RunStatus.COMPLETED,
+            current_state=current_state,
             results=[
                 {
                     "agent": result.agent,
@@ -197,6 +275,7 @@ class OrchestratorService:
                 }
                 for result in results
             ],
+            steps=[step.to_dict() for step in steps],
         )
 
         next_history = [HistoryItem(**item) for item in final_context.history]
@@ -210,9 +289,12 @@ class OrchestratorService:
         return OrchestratorRun(
             run_id=run_id,
             session_id=session_id,
-            status="completed",
+            status=RunStatus.COMPLETED,
+            run_type=run_type,
+            current_state=current_state,
             history=next_history,
             results=results,
+            steps=steps,
         )
 
     def get_plan(self, session_id: str) -> PlanSession:
@@ -223,7 +305,7 @@ class OrchestratorService:
             session_id=state["id"],
             goal=state["goal"],
             plan=list(state["plan"] or []),
-            status="awaiting_input",
+            status=RunStatus.AWAITING_INPUT,
         )
 
     def list_sessions(self) -> List[SessionSummary]:
@@ -250,7 +332,7 @@ class OrchestratorService:
             session_id=record["id"],
             goal=record["goal"],
             plan=list(record["plan"] or []),
-            status="awaiting_input",
+            status=RunStatus.AWAITING_INPUT,
             history=history,
         )
 
@@ -267,9 +349,22 @@ class OrchestratorService:
             run_id=record["id"],
             session_id=record["session_id"],
             status=record["status"],
+            run_type=record["run_type"],
+            current_state=record["current_state"],
             trigger_message=record["trigger_message"],
             created_at=record["created_at"],
             results=results,
+            steps=[
+                RunStep(
+                    step_key=item["step_key"],
+                    agent=item["agent"],
+                    status=item["status"],
+                    started_at=item["started_at"],
+                    completed_at=item["completed_at"],
+                    attempt=item.get("attempt", 1),
+                )
+                for item in (record["steps"] or [])
+            ],
         )
 
     def _extract_plan_steps(self, plan_result: AgentResult) -> List[str]:
@@ -322,19 +417,51 @@ class OrchestratorService:
         def node(state: AgentGraphState) -> AgentGraphState:
             agent = self._require_agent(agent_name)
             context = state["context"]
+            started_at = self._timestamp()
             agent_result: AgentResult = agent.run(context)
             execution = AgentExecution(
                 agent=agent.name,
                 content=agent_result.content,
                 metadata=agent_result.metadata,
             )
+            completed_at = self._timestamp()
             next_context = context.with_artifact(agent.name, agent_result.metadata)
             next_context = next_context.with_message(agent.name, agent_result.content)
             next_results = list(state["results"])
             next_results.append(execution)
-            return {"context": next_context, "results": next_results}
+            next_steps = list(state["steps"])
+            next_steps.append(
+                RunStep(
+                    step_key=agent_name,
+                    agent=agent.name,
+                    status=StepStatus.COMPLETED,
+                    started_at=started_at,
+                    completed_at=completed_at,
+                )
+            )
+            return {
+                "context": next_context,
+                "results": next_results,
+                "steps": next_steps,
+                "current_state": "completed",
+            }
 
         return node
 
     def _clone_artifacts(self, artifacts: Mapping[str, Mapping[str, Any]]) -> Dict[str, Dict[str, Any]]:
         return {name: dict(meta) for name, meta in artifacts.items()}
+
+    def _infer_run_type(self, *, goal: str, message: str) -> RunType:
+        combined = f"{goal} {message}".lower()
+        if any(keyword in combined for keyword in ("doc", "readme", "documentation")):
+            return RunType.DOCUMENTATION_UPDATE
+        if any(keyword in combined for keyword in ("infra", "deploy", "docker", "kubernetes", "terraform")):
+            return RunType.DEVOPS_CHANGE
+        if any(keyword in combined for keyword in ("validate", "validation", "test", "lint", "typecheck")):
+            return RunType.VALIDATION_ONLY
+        if any(keyword in combined for keyword in ("bootstrap", "greenfield", "new project", "from scratch")):
+            return RunType.GREENFIELD_BOOTSTRAP
+        return RunType.EXISTING_REPO_CHANGE
+
+    def _timestamp(self) -> str:
+        return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/backend/persistence/database.py
+++ b/backend/persistence/database.py
@@ -43,11 +43,25 @@ class DurableStore:
                     id TEXT PRIMARY KEY,
                     session_id TEXT NOT NULL,
                     status TEXT NOT NULL,
+                    run_type TEXT NOT NULL DEFAULT 'existing_repo_change',
+                    current_state TEXT NOT NULL DEFAULT 'starting',
                     trigger_message TEXT NOT NULL,
                     results_json TEXT NOT NULL,
                     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     completed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     FOREIGN KEY(session_id) REFERENCES sessions(id)
+                );
+
+                CREATE TABLE IF NOT EXISTS run_steps (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id TEXT NOT NULL,
+                    step_key TEXT NOT NULL,
+                    agent TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    started_at TEXT NOT NULL,
+                    completed_at TEXT NOT NULL,
+                    attempt INTEGER NOT NULL DEFAULT 1,
+                    FOREIGN KEY(run_id) REFERENCES runs(id)
                 );
 
                 CREATE TABLE IF NOT EXISTS messages (
@@ -63,9 +77,12 @@ class DurableStore:
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_runs_session_id ON runs(session_id);
+                CREATE INDEX IF NOT EXISTS idx_run_steps_run_id ON run_steps(run_id, id);
                 CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, sequence);
                 """
             )
+            self._ensure_column(connection, "runs", "run_type", "TEXT NOT NULL DEFAULT 'existing_repo_change'")
+            self._ensure_column(connection, "runs", "current_state", "TEXT NOT NULL DEFAULT 'starting'")
             connection.commit()
 
     def connect(self) -> sqlite3.Connection:
@@ -124,17 +141,42 @@ class DurableStore:
         run_id: str,
         session_id: str,
         status: str,
+        run_type: str,
+        current_state: str,
         trigger_message: str,
         results: list[dict[str, Any]],
+        steps: list[dict[str, Any]],
     ) -> None:
         with self.connect() as connection:
             connection.execute(
                 """
-                INSERT INTO runs (id, session_id, status, trigger_message, results_json)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO runs (id, session_id, status, run_type, current_state, trigger_message, results_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
-                (run_id, session_id, status, trigger_message, json.dumps(results)),
+                (run_id, session_id, status, run_type, current_state, trigger_message, json.dumps(results)),
             )
+            self._replace_run_steps(connection, run_id, steps)
+            connection.commit()
+
+    def update_run(
+        self,
+        *,
+        run_id: str,
+        status: str,
+        current_state: str,
+        results: list[dict[str, Any]],
+        steps: list[dict[str, Any]],
+    ) -> None:
+        with self.connect() as connection:
+            connection.execute(
+                """
+                UPDATE runs
+                SET status = ?, current_state = ?, results_json = ?, completed_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """,
+                (status, current_state, json.dumps(results), run_id),
+            )
+            self._replace_run_steps(connection, run_id, steps)
             connection.commit()
 
     def list_runs(self, session_id: str) -> list[dict[str, Any]]:
@@ -190,11 +232,27 @@ class DurableStore:
             "id": row["id"],
             "session_id": row["session_id"],
             "status": row["status"],
+            "run_type": row["run_type"],
+            "current_state": row["current_state"],
             "trigger_message": row["trigger_message"],
             "results": json.loads(row["results_json"]),
+            "steps": self.list_run_steps(row["id"]),
             "created_at": row["created_at"],
             "completed_at": row["completed_at"],
         }
+
+    def list_run_steps(self, run_id: str) -> list[dict[str, Any]]:
+        with self.connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT step_key, agent, status, started_at, completed_at, attempt
+                FROM run_steps
+                WHERE run_id = ?
+                ORDER BY id ASC
+                """,
+                (run_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]
 
     def _resolve_database_path(self, database_url: str) -> Path:
         normalized = database_url.strip() or DEFAULT_DATABASE_URL
@@ -207,6 +265,49 @@ class DurableStore:
         raise ValueError(
             "The initial durable slice currently supports only sqlite DATABASE_URL values. "
             "Use a URL like sqlite:///./autodev.db."
+        )
+
+    def _ensure_column(
+        self,
+        connection: sqlite3.Connection,
+        table_name: str,
+        column_name: str,
+        column_definition: str,
+    ) -> None:
+        existing_columns = {
+            row["name"]
+            for row in connection.execute(f"PRAGMA table_info({table_name})").fetchall()
+        }
+        if column_name in existing_columns:
+            return
+        connection.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_definition}")
+
+    def _replace_run_steps(
+        self,
+        connection: sqlite3.Connection,
+        run_id: str,
+        steps: list[dict[str, Any]],
+    ) -> None:
+        connection.execute("DELETE FROM run_steps WHERE run_id = ?", (run_id,))
+        if not steps:
+            return
+        connection.executemany(
+            """
+            INSERT INTO run_steps (run_id, step_key, agent, status, started_at, completed_at, attempt)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    run_id,
+                    step["step_key"],
+                    step["agent"],
+                    step["status"],
+                    step["started_at"],
+                    step["completed_at"],
+                    step.get("attempt", 1),
+                )
+                for step in steps
+            ],
         )
 
 

--- a/docs/implementation/data_model.md
+++ b/docs/implementation/data_model.md
@@ -21,6 +21,9 @@ Represents one executable workflow instance.
 ### RunStep
 Represents an individual step/state transition inside a run.
 
+Current bootstrap slice:
+- SQLite now persists `runs.current_state`, `runs.run_type`, and ordered `run_steps` records so workflow progress survives restarts before the PostgreSQL migration.
+
 ### Message
 Stores conversational and system messages.
 
@@ -103,4 +106,3 @@ Each important transition should create an audit/event record, including:
 - patch approved/rejected
 - validation started/completed
 - run completed/failed/cancelled
-

--- a/docs/implementation/implementation_strategy.md
+++ b/docs/implementation/implementation_strategy.md
@@ -59,6 +59,11 @@ Current functional slice in this repository:
 - retry policies;
 - partial rerun support.
 
+Current functional slice in this repository:
+- runs now persist an explicit `run_type` classification and `current_state`;
+- ordered `run_steps` records capture which workflow stages completed for each run;
+- the synchronous LangGraph chain now emits machine-readable step history, leaving conditional routing, retries, and partial reruns for the next slice.
+
 ### Suggested run types
 - `greenfield_bootstrap`
 - `existing_repo_change`
@@ -215,4 +220,3 @@ Use layered retrieval:
 - using large-context prompting as a substitute for repository intelligence;
 - rewriting full files when targeted patches are possible;
 - adding too many infrastructure systems before the workflow needs them.
-

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,6 +31,7 @@ Goals:
 Current implementation status:
 - durable sessions, runs, and message history are now persisted via a SQLite-backed bootstrap store;
 - API endpoints expose session and run history for inspection;
+- explicit run typing and persisted run-step history now provide the first workflow-state slice;
 - PostgreSQL and Redis-backed async execution remain pending in the next slices.
 
 Success criteria:
@@ -41,6 +42,11 @@ Success criteria:
 ---
 
 ## Release 0.3 - Repository intelligence
+
+Current implementation status:
+- run records now distinguish workflow types such as documentation, validation, devops, and existing-repository change;
+- each run now persists ordered workflow steps, creating a bridge from the bootstrap durable control plane to a fuller state machine;
+- tree-sitter indexing, retrieval, and repository metadata storage remain the next major capability gap.
 
 Goals:
 - tree-sitter indexing
@@ -97,4 +103,3 @@ Goals:
 Success criteria:
 - self-hosted install succeeds with only open source dependencies
 - project becomes viable as an OSS alternative in the GenAI coding workflow space
-

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -44,6 +44,9 @@ def test_session_and_run_endpoints(client: TestClient) -> None:
     chat_payload = chat_response.json()
     assert chat_payload["status"] == "completed"
     assert chat_payload["run_id"]
+    assert chat_payload["run_type"] == "existing_repo_change"
+    assert chat_payload["current_state"] == "completed"
+    assert chat_payload["steps"][0]["step_key"] == "navigator"
 
     session_response = client.get(f"/sessions/{session_id}")
     assert session_response.status_code == 200
@@ -58,3 +61,5 @@ def test_session_and_run_endpoints(client: TestClient) -> None:
     runs_payload = runs_response.json()
     assert len(runs_payload) == 1
     assert runs_payload[0]["trigger_message"] == "Execute the first iteration"
+    assert runs_payload[0]["run_type"] == "existing_repo_change"
+    assert runs_payload[0]["steps"]

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -37,10 +37,15 @@ def test_handle_message_returns_agent_responses(orchestrator_service: Orchestrat
 
     assert result.run_id
     assert result.status == "completed"
+    assert result.run_type == "existing_repo_change"
+    assert result.current_state == "completed"
     assert result.session_id == session.session_id
     agent_names = [execution.agent for execution in result.results]
     assert "navigator" in agent_names
     assert any("DevOps" in execution.content for execution in result.results)
+    assert len(result.steps) == len(result.results)
+    assert result.steps[0].step_key == "navigator"
+    assert all(step.status == "completed" for step in result.steps)
     assert result.history[0].role == "user"
     assert result.history[0].content == "Start execution"
     assert all(entry.content for entry in result.history)
@@ -78,7 +83,18 @@ def test_run_history_is_queryable(orchestrator_service: OrchestratorService) -> 
     assert len(runs) == 2
     assert runs[0].trigger_message == "Run twice"
     assert runs[1].trigger_message == "Run once"
+    assert runs[0].run_type == "existing_repo_change"
+    assert runs[0].current_state == "completed"
     assert runs[0].results
+    assert runs[0].steps
+
+
+def test_run_type_inference_uses_workflow_categories(orchestrator_service: OrchestratorService) -> None:
+    session = orchestrator_service.create_plan("Refresh README guidance")
+
+    result = orchestrator_service.handle_message(session.session_id, "Update documentation for operators")
+
+    assert result.run_type == "documentation_update"
 
 
 class PlannerWithoutMetadata:


### PR DESCRIPTION
### Motivation
- Advance the roadmap from the durable control-plane bootstrap toward an explicit workflow-state slice by adding run typing and step history so workflow progress and type survive restarts. 
- Provide a minimal, reviewable foundation for an eventual explicit run state machine, approval gates, and partial reruns while keeping changes backward-compatible with the SQLite bootstrap store. 

### Description
- Add typed workflow primitives: `RunType`, `RunStatus`, `StepStatus`, and `RunStep`, and surface `run_type`, `current_state`, and ordered `steps` on `OrchestratorRun` and `RunSummary` responses. 
- Emit per-agent step records from the LangGraph chain with timestamps and persist them to SQLite via new `run_steps` table and `runs.run_type`/`runs.current_state` columns, plus DB helpers `_ensure_column` and `_replace_run_steps`. 
- Extend the orchestrator to create an initial `run` record with `RUNNING` status, infer `run_type` from `goal`/`message` via `_infer_run_type`, update runs via `update_run`, and append `RunStep` entries as agents execute. 
- Expose the new workflow fields in the API by adding `RunStepModel` and returning `run_type`, `current_state`, and `steps` from `/chat` and run history endpoints. 
- Update docs (`README.md`, `docs/roadmap.md`, `docs/implementation/*`, `docs/implementation/data_model.md`) to reflect the new bootstrap slice and adjust tests to validate the new behavior. 

### Testing
- Ran the test suite with `pytest`, all tests passed (`7 passed`).
- Verified bytecode compilation with `python -m compileall backend tests` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfdcf57ddc832a939135c63a8e20c8)