### PR TITLE
Add repository context retrieval slice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # Backend runtime
 DATABASE_URL=sqlite:///./autodev.db
 LLM_PROVIDER=stub
+# Set LLM_PROVIDER=openai to enable a real agent API.
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
+OPENAI_BASE_URL=
+OPENAI_TEMPERATURE=0.2
 UVICORN_RELOAD=true
 
 # Frontend runtime

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -19,6 +19,8 @@ Build an open source control plane for software engineering agents that can help
 
 Instead of acting like a black-box chatbot that emits code snippets, AutoDev Architect aims to become an **auditable engineering workflow system** that combines planning, code intelligence, patching, validation, and human approval.
 
+The current implementation already includes a bootstrap durable control plane, persisted workflow-step history, configurable stub/OpenAI agent execution, and a first repository-context retrieval API for ranked file discovery.
+
 ---
 
 ## Core problem

--- a/README.md
+++ b/README.md
@@ -235,11 +235,39 @@ This repository is still in the transition from prototype to platform. The new d
 
 ### Local installation
 
-1. Copy `.env.example` if you want to customize runtime variables.
+1. Copy `.env.example` if you want to customize runtime variables: `cp .env.example .env`.
 2. Run `./scripts/install_dependencies.sh`.
-3. Optionally adjust `DATABASE_URL` (the first functional stage uses SQLite by default).
-4. Start the backend with `source .venv/bin/activate && uvicorn backend.api.main:app --reload`.
-5. Start the frontend with `cd frontend && npm run dev`.
+3. Adjust `DATABASE_URL` if you want to move the bootstrap durable store away from the default SQLite file.
+4. Configure the agent API / LLM provider:
+   - keep `LLM_PROVIDER=stub` for fully local deterministic fallback behavior; or
+   - set `LLM_PROVIDER=openai` and fill `OPENAI_API_KEY`, plus optional `OPENAI_MODEL`, `OPENAI_BASE_URL`, and `OPENAI_TEMPERATURE`.
+5. Start the backend with `source .venv/bin/activate && uvicorn backend.api.main:app --reload`.
+6. Start the frontend with `cd frontend && npm run dev`.
+
+### Configuring the agent API
+
+The backend defaults to a `stub` provider so the platform remains self-hostable even without a paid model API. When you want live LLM-backed agent behavior, export these variables before starting the backend:
+
+```bash
+export LLM_PROVIDER=openai
+export OPENAI_API_KEY=your_key_here
+export OPENAI_MODEL=gpt-4o-mini
+# Optional when using a compatible gateway or proxy
+export OPENAI_BASE_URL=
+export OPENAI_TEMPERATURE=0.2
+```
+
+If `LLM_PROVIDER=openai` is set without `OPENAI_API_KEY`, the backend falls back to the deterministic stub model instead of crashing.
+
+### Repository context API
+
+The first repository-intelligence slice now exposes `GET /repository/context`, which returns a structured inventory summary plus ranked candidate files for a query. Example:
+
+```bash
+curl "http://localhost:8000/repository/context?query=agent%20api&limit=5"
+```
+
+This endpoint is intended to seed later tree-sitter, FTS, and vector-based retrieval work with an explicit machine-readable contract.
 
 ### Docker option
 

--- a/backend/agents/navigator/agent.py
+++ b/backend/agents/navigator/agent.py
@@ -3,20 +3,20 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
 
 from langchain_core.prompts import ChatPromptTemplate
 
 from backend.agents.base import AgentContext, AgentResult, LangChainAgent
+from backend.repository import RepositoryIntelligenceService
 
 
 class NavigatorAgent(LangChainAgent):
-    """Provide a lightweight map of the repository structure."""
+    """Provide a lightweight but structured map of the repository."""
 
     name = "navigator"
 
     def __init__(self, project_root: Path | None = None) -> None:
-        self._root = project_root or Path.cwd()
+        self._service = RepositoryIntelligenceService(project_root=project_root)
         super().__init__()
 
     def build_prompt(self) -> ChatPromptTemplate:
@@ -24,39 +24,65 @@ class NavigatorAgent(LangChainAgent):
             [
                 (
                     "system",
-                    "You are the Navigator agent. Inspect the project workspace and give "
-                    "a concise overview of its main directories.",
+                    "You are the Navigator agent. Inspect the repository context and return "
+                    "a concise repository map with the most relevant files for the task.",
                 ),
                 (
                     "human",
                     "Root path: {root}\n"
-                    "Existing directories:\n{directories}\n"
-                    "Summarise the workspace structure for the other agents.",
+                    "User goal: {goal}\n"
+                    "Recent history:\n{history}\n"
+                    "Top directories: {directories}\n"
+                    "Candidate files: {candidate_files}\n"
+                    "Inventory sample:\n{inventory_sample}\n"
+                    "Summarise which files or areas other agents should inspect first.",
                 ),
             ]
         )
 
     def prepare_inputs(self, context: AgentContext) -> dict[str, str]:
         inputs = super().prepare_inputs(context)
-        directories = self._scan_directories()
-        inputs["root"] = str(self._root)
-        inputs["directories"] = "\n".join(directories) if directories else "(empty)"
+        repository_context = self._build_repository_context(context)
+        inputs["root"] = repository_context.root
+        inputs["directories"] = ", ".join(repository_context.top_directories) or "(none)"
+        inputs["candidate_files"] = self._render_candidate_files(repository_context)
+        inputs["inventory_sample"] = "\n".join(repository_context.inventory_sample) or "(empty)"
         return inputs
 
     def fallback_result(self, context: AgentContext) -> AgentResult:
-        directories = self._scan_directories()
-        message = "Indexed top-level directories: " + ", ".join(directories)
-        metadata = {"directories": directories, "root": str(self._root)}
-        return AgentResult(content=message, metadata=metadata)
+        repository_context = self._build_repository_context(context)
+        candidate_paths = [item.path for item in repository_context.candidate_files]
+        if candidate_paths:
+            message = (
+                "Repository context prepared. Prioritise these files: "
+                + ", ".join(candidate_paths)
+            )
+        else:
+            message = (
+                "Repository context prepared. No strong file matches were found, "
+                "so use the inventory sample as a starting point."
+            )
+        return AgentResult(content=message, metadata=repository_context.to_dict())
 
-    def _scan_directories(self) -> List[str]:
-        directories: List[str] = []
-        for path in sorted(self._root.iterdir()):
-            if path.name.startswith("."):
-                continue
-            if path.is_dir():
-                directories.append(path.name)
-        return directories
+    def _build_repository_context(self, context: AgentContext):
+        query = self._build_query(context)
+        return self._service.build_context(query=query, limit=8)
+
+    def _build_query(self, context: AgentContext) -> str:
+        recent_user_messages = [
+            entry.get("content", "")
+            for entry in context.history
+            if entry.get("role") == "user"
+        ]
+        return "\n".join(filter(None, [context.goal or "", *recent_user_messages]))
+
+    def _render_candidate_files(self, repository_context) -> str:
+        if not repository_context.candidate_files:
+            return "(no direct matches)"
+        return "\n".join(
+            f"- {item.path} (score={item.score}; reasons={', '.join(item.reasons)})"
+            for item in repository_context.candidate_files
+        )
 
 
 __all__ = ["NavigatorAgent"]

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -6,6 +6,8 @@ from contextlib import asynccontextmanager
 from functools import lru_cache
 from typing import Dict, List
 
+from pathlib import Path
+
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
@@ -20,6 +22,8 @@ from backend.orchestrator.service import (
     RunSummary,
     SessionSummary,
 )
+
+from backend.repository import RepositoryContext, RepositoryIntelligenceService
 
 
 class PlanRequest(BaseModel):
@@ -58,6 +62,22 @@ class HistoryItemModel(BaseModel):
     content: str
 
 
+class RepositoryFileMatchModel(BaseModel):
+    path: str
+    score: int
+    reasons: List[str]
+
+
+class RepositoryContextResponse(BaseModel):
+    query: str
+    root: str
+    total_files: int
+    top_directories: List[str]
+    candidate_files: List[RepositoryFileMatchModel]
+    inventory_sample: List[str]
+    matched_terms: List[str]
+
+
 class ChatResponse(BaseModel):
     run_id: str
     session_id: str
@@ -92,6 +112,11 @@ class RunResponse(BaseModel):
 @lru_cache(maxsize=1)
 def get_orchestrator() -> OrchestratorService:
     return OrchestratorService(config=OrchestratorConfig())
+
+
+@lru_cache(maxsize=1)
+def get_repository_intelligence() -> RepositoryIntelligenceService:
+    return RepositoryIntelligenceService(project_root=Path.cwd())
 
 
 @asynccontextmanager
@@ -170,6 +195,27 @@ def list_runs(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
     return [_to_run_response(run) for run in runs]
+
+
+@app.get("/repository/context", response_model=RepositoryContextResponse, tags=["repository"])
+def get_repository_context(
+    query: str = "",
+    limit: int = 8,
+    repository_intelligence: RepositoryIntelligenceService = Depends(get_repository_intelligence),
+) -> RepositoryContextResponse:
+    repository_context: RepositoryContext = repository_intelligence.build_context(query=query, limit=max(1, min(limit, 25)))
+    return RepositoryContextResponse(
+        query=repository_context.query,
+        root=repository_context.root,
+        total_files=repository_context.total_files,
+        top_directories=repository_context.top_directories,
+        candidate_files=[
+            RepositoryFileMatchModel(path=item.path, score=item.score, reasons=item.reasons)
+            for item in repository_context.candidate_files
+        ],
+        inventory_sample=repository_context.inventory_sample,
+        matched_terms=repository_context.matched_terms,
+    )
 
 
 @app.post("/chat", response_model=ChatResponse, tags=["chat"])

--- a/backend/repository/__init__.py
+++ b/backend/repository/__init__.py
@@ -1,0 +1,9 @@
+"""Repository intelligence helpers."""
+
+from backend.repository.intelligence import RepositoryContext, RepositoryFileMatch, RepositoryIntelligenceService
+
+__all__ = [
+    "RepositoryContext",
+    "RepositoryFileMatch",
+    "RepositoryIntelligenceService",
+]

--- a/backend/repository/intelligence.py
+++ b/backend/repository/intelligence.py
@@ -1,0 +1,213 @@
+"""Lightweight repository intelligence used by the navigator and API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+@dataclass(slots=True)
+class RepositoryFileMatch:
+    """Represents a file selected as relevant for a query."""
+
+    path: str
+    score: int
+    reasons: list[str]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "score": self.score,
+            "reasons": list(self.reasons),
+        }
+
+
+@dataclass(slots=True)
+class RepositoryContext:
+    """Structured repository context returned for a query."""
+
+    query: str
+    root: str
+    total_files: int
+    top_directories: list[str]
+    candidate_files: list[RepositoryFileMatch]
+    inventory_sample: list[str]
+    matched_terms: list[str]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "query": self.query,
+            "root": self.root,
+            "total_files": self.total_files,
+            "top_directories": list(self.top_directories),
+            "candidate_files": [item.to_dict() for item in self.candidate_files],
+            "inventory_sample": list(self.inventory_sample),
+            "matched_terms": list(self.matched_terms),
+        }
+
+
+class RepositoryIntelligenceService:
+    """Collect and rank repository context without requiring external infrastructure."""
+
+    _ignored_directories = {
+        ".git",
+        ".next",
+        ".venv",
+        "__pycache__",
+        "node_modules",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".turbo",
+        ".idea",
+        ".vscode",
+    }
+
+    _preferred_extensions = {
+        ".md",
+        ".py",
+        ".ts",
+        ".tsx",
+        ".js",
+        ".jsx",
+        ".json",
+        ".yml",
+        ".yaml",
+        ".toml",
+        ".sh",
+        ".tf",
+    }
+
+    def __init__(self, project_root: Path | None = None) -> None:
+        self._root = (project_root or Path.cwd()).resolve()
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def build_context(self, query: str, limit: int = 8) -> RepositoryContext:
+        normalized_query = query.strip()
+        files = self._list_files()
+        top_directories = self._top_directories(files)
+        matches = self._rank_files(files, normalized_query, limit=limit)
+        inventory_sample = [self._relative_path(path) for path in files[: min(12, len(files))]]
+        matched_terms = self._extract_terms(normalized_query)
+        return RepositoryContext(
+            query=normalized_query,
+            root=str(self._root),
+            total_files=len(files),
+            top_directories=top_directories,
+            candidate_files=matches,
+            inventory_sample=inventory_sample,
+            matched_terms=matched_terms,
+        )
+
+    def _list_files(self) -> list[Path]:
+        files: list[Path] = []
+        for path in sorted(self._root.rglob("*")):
+            if not path.is_file():
+                continue
+            if self._should_ignore(path):
+                continue
+            if path.suffix and path.suffix not in self._preferred_extensions:
+                continue
+            files.append(path)
+        return files
+
+    def _should_ignore(self, path: Path) -> bool:
+        return any(part in self._ignored_directories for part in path.parts)
+
+    def _rank_files(self, files: Sequence[Path], query: str, limit: int) -> list[RepositoryFileMatch]:
+        terms = self._extract_terms(query)
+        if not terms:
+            return [
+                RepositoryFileMatch(path=self._relative_path(path), score=0, reasons=["inventory_sample"])
+                for path in files[:limit]
+            ]
+
+        scored: list[RepositoryFileMatch] = []
+        for path in files:
+            relative_path = self._relative_path(path)
+            path_lower = relative_path.lower()
+            name_lower = path.name.lower()
+            parent_lower = str(path.parent.relative_to(self._root)).lower() if path.parent != self._root else ""
+            score = 0
+            reasons: list[str] = []
+
+            for term in terms:
+                if term in name_lower:
+                    score += 5
+                    reasons.append(f"filename:{term}")
+                elif term in path_lower:
+                    score += 3
+                    reasons.append(f"path:{term}")
+                elif term in parent_lower:
+                    score += 2
+                    reasons.append(f"directory:{term}")
+
+            if score <= 0:
+                continue
+
+            preferred_boost = 2 if path.name.lower() in {"readme.md", "description.md", "docker-compose.yml"} else 0
+            scored.append(
+                RepositoryFileMatch(
+                    path=relative_path,
+                    score=score + preferred_boost,
+                    reasons=self._unique(reasons),
+                )
+            )
+
+        scored.sort(key=lambda item: (-item.score, item.path))
+        return scored[:limit]
+
+    def _top_directories(self, files: Iterable[Path]) -> list[str]:
+        counts: dict[str, int] = {}
+        for path in files:
+            relative_parts = path.relative_to(self._root).parts
+            if len(relative_parts) < 2:
+                continue
+            first = relative_parts[0]
+            counts[first] = counts.get(first, 0) + 1
+        return [name for name, _ in sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:6]]
+
+    def _extract_terms(self, query: str) -> list[str]:
+        stop_words = {
+            "a",
+            "the",
+            "do",
+            "da",
+            "de",
+            "e",
+            "o",
+            "os",
+            "as",
+            "to",
+            "for",
+            "and",
+            "agente",
+            "configurar",
+            "implementar",
+            "etapa",
+            "proxima",
+            "próxima",
+        }
+        terms: list[str] = []
+        for chunk in query.replace("/", " ").replace("_", " ").replace("-", " ").split():
+            normalized = chunk.strip().lower().strip(".,:;!?()[]{}\"'")
+            if len(normalized) < 3 or normalized in stop_words:
+                continue
+            terms.append(normalized)
+        return self._unique(terms)
+
+    def _relative_path(self, path: Path) -> str:
+        return str(path.relative_to(self._root))
+
+    def _unique(self, items: Iterable[str]) -> list[str]:
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for item in items:
+            if item in seen:
+                continue
+            seen.add(item)
+            ordered.append(item)
+        return ordered

--- a/backend/tests/test_api_repository_context.py
+++ b/backend/tests/test_api_repository_context.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.api.main import app, get_repository_intelligence
+from backend.repository import RepositoryIntelligenceService
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def test_repository_context_endpoint_returns_ranked_matches(tmp_path: Path) -> None:
+    _write(tmp_path / "README.md", "project readme")
+    _write(tmp_path / "backend" / "api" / "main.py", "from fastapi import FastAPI")
+    _write(tmp_path / "docs" / "implementation" / "agent_spec.md", "agent api configuration")
+
+    app.dependency_overrides[get_repository_intelligence] = lambda: RepositoryIntelligenceService(project_root=tmp_path)
+    client = TestClient(app)
+
+    response = client.get("/repository/context", params={"query": "agent api", "limit": 2})
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total_files"] == 3
+    assert payload["candidate_files"]
+    assert payload["candidate_files"][0]["path"] in {
+        "docs/implementation/agent_spec.md",
+        "backend/api/main.py",
+    }
+    assert payload["matched_terms"] == ["agent", "api"]

--- a/backend/tests/test_repository_intelligence.py
+++ b/backend/tests/test_repository_intelligence.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from backend.agents.base import AgentContext
+from backend.agents.navigator.agent import NavigatorAgent
+from backend.repository import RepositoryIntelligenceService
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def test_repository_context_ranks_relevant_files(tmp_path: Path) -> None:
+    _write(tmp_path / "README.md", "project readme")
+    _write(tmp_path / "backend" / "api" / "main.py", "from fastapi import FastAPI")
+    _write(tmp_path / "backend" / "agents" / "navigator" / "agent.py", "class NavigatorAgent: ...")
+    _write(tmp_path / "docs" / "implementation" / "agent_spec.md", "agent api configuration")
+    _write(tmp_path / "frontend" / "app" / "page.tsx", "export default function Page() {}")
+    _write(tmp_path / "frontend" / "node_modules" / "ignored.js", "ignored")
+
+    service = RepositoryIntelligenceService(project_root=tmp_path)
+
+    context = service.build_context(query="configurar api do agent", limit=5)
+
+    assert context.total_files == 5
+    assert "backend" in context.top_directories
+    assert any(match.path == "docs/implementation/agent_spec.md" for match in context.candidate_files)
+    assert all("node_modules" not in item.path for item in context.candidate_files)
+    assert context.matched_terms == ["api", "agent"]
+
+
+def test_navigator_agent_returns_structured_repository_metadata(tmp_path: Path) -> None:
+    _write(tmp_path / "README.md", "project readme")
+    _write(tmp_path / "backend" / "api" / "main.py", "from fastapi import FastAPI")
+    _write(tmp_path / "docs" / "implementation" / "agent_spec.md", "agent api configuration")
+
+    agent = NavigatorAgent(project_root=tmp_path)
+    result = agent.run(
+        AgentContext(
+            session_id="session-1",
+            goal="Documentar a API do agent",
+            history=[{"role": "user", "content": "falta instrução pra configurar a api do agent"}],
+        )
+    )
+
+    assert "candidate_files" in result.metadata
+    candidate_files = result.metadata["candidate_files"]
+    assert candidate_files
+    assert candidate_files[0]["path"] in {
+        "docs/implementation/agent_spec.md",
+        "backend/api/main.py",
+    }
+    assert result.metadata["total_files"] == 3

--- a/docs/implementation/implementation_strategy.md
+++ b/docs/implementation/implementation_strategy.md
@@ -87,6 +87,11 @@ Current functional slice in this repository:
 - pgvector embeddings and retrieval API;
 - repository context selection service.
 
+Current functional slice in this repository:
+- a lightweight repository intelligence service now builds a structured file inventory with ignored-directory rules for common generated folders;
+- the navigator agent now emits machine-readable candidate files, top directories, inventory samples, and matched query terms;
+- `GET /repository/context` exposes the first repository-context retrieval contract for future tree-sitter, FTS, and pgvector upgrades.
+
 ### Retrieval strategy
 Use layered retrieval:
 1. lexical narrowing;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,8 @@ Success criteria:
 Current implementation status:
 - run records now distinguish workflow types such as documentation, validation, devops, and existing-repository change;
 - each run now persists ordered workflow steps, creating a bridge from the bootstrap durable control plane to a fuller state machine;
-- tree-sitter indexing, retrieval, and repository metadata storage remain the next major capability gap.
+- a first repository-intelligence slice now exposes structured file inventory and ranked candidate-file retrieval via the navigator and `GET /repository/context`;
+- tree-sitter indexing, deeper retrieval, and repository metadata storage remain the next major capability gap.
 
 Goals:
 - tree-sitter indexing


### PR DESCRIPTION
### Motivation
- Provide an initial, infrastructure-light repository intelligence slice so agents can return machine-readable file context and prioritize relevant files for a user query. 
- Make it explicit how to configure the agent/LLM provider so local fallback (`stub`) remains the default while enabling an OpenAI path. 
- Expose a typed HTTP contract to seed later tree-sitter/FTS/pgvector retrieval work.

### Description
- Add a lightweight repository intelligence service (`backend/repository/intelligence.py` and `backend/repository/__init__.py`) that inventories files, ignores common generated directories, extracts query terms, and ranks candidate files as `RepositoryFileMatch` objects. 
- Update the `NavigatorAgent` to consume the structured repository context and emit machine-readable metadata (top directories, candidate files, inventory sample, matched terms) for downstream agents (`backend/agents/navigator/agent.py`). 
- Add a new FastAPI endpoint `GET /repository/context` with Pydantic response models (`RepositoryContextResponse`, `RepositoryFileMatchModel`) in `backend/api/main.py` to return the ranked repository context. 
- Document agent/LLM configuration and the new endpoint by updating `.env.example`, `README.md`, `DESCRIPTION.md`, `docs/implementation/implementation_strategy.md`, and `docs/roadmap.md`. 
- Add backend tests covering the repository ranking, navigator metadata, and the API endpoint (`backend/tests/test_repository_intelligence.py` and `backend/tests/test_api_repository_context.py`).

### Testing
- Ran unit tests with `PYTHONPATH=. pytest backend/tests -q`, which passed (`3 passed`).
- Verified bytecode compilation with `python -m compileall backend`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfdeec4e88832aa0289138127cf9ff)