### PR TITLE
Add Python 3.10 backend compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ This repository is still in the transition from prototype to platform. The new d
 ### Local installation
 
 1. Copy `.env.example` if you want to customize runtime variables: `cp .env.example .env`.
-2. Run `./scripts/install_dependencies.sh`.
+2. Run `./scripts/install_dependencies.sh` with Python 3.10+ available as `python3` (or override `PYTHON_BIN`).
 3. Adjust `DATABASE_URL` if you want to move the bootstrap durable store away from the default SQLite file.
 4. Configure the agent API / LLM provider:
    - keep `LLM_PROVIDER=stub` for fully local deterministic fallback behavior; or

--- a/backend/agents/devops/agent.py
+++ b/backend/agents/devops/agent.py
@@ -32,7 +32,7 @@ class DevOpsAgent(LangChainAgent):
 
     def fallback_result(self, context: AgentContext) -> AgentResult:
         deliverables = {
-            "docker": "Create Python 3.11 image exposing the FastAPI app",
+            "docker": "Create Python 3.10+ image exposing the FastAPI app",
             "ci": "Configure GitHub Actions workflow running tests and lint",
             "infrastructure": "Prepare Terraform placeholder for future cloud resources",
         }

--- a/backend/orchestrator/service.py
+++ b/backend/orchestrator/service.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from enum import StrEnum
+try:
+    from enum import StrEnum
+except ImportError:  # pragma: no cover - Python < 3.11 compatibility
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Fallback StrEnum compatible with Python 3.10."""
+
+        pass
+
 from typing import Any, Dict, Iterable, List, Mapping, TypedDict
 from pathlib import Path
 from uuid import uuid4

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,7 +3,7 @@ name = "autodev-backend"
 version = "0.1.0"
 description = "Backend services for the AutoDev Architect platform"
 readme = "../README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [
   { name = "AutoDev Team" }

--- a/docs/architecture/initial_architecture.md
+++ b/docs/architecture/initial_architecture.md
@@ -14,7 +14,7 @@ This document consolidates the early agreements for the AutoDev Architect platfo
 
 | Area | Purpose | Initial Decision |
 | --- | --- | --- |
-| Backend Orchestrator | Coordinate Planner → Navigator/Analyzer → Architect → Coder → DevOps → Validator | Python 3.11 + FastAPI service with in-memory session store. |
+| Backend Orchestrator | Coordinate Planner → Navigator/Analyzer → Architect → Coder → DevOps → Validator | Python 3.10+ FastAPI service with in-memory session store. |
 | Agent Implementations | Encapsulate behaviour per specialty | Shared `AgentContext`/`AgentResult` contracts. Stubs provide deterministic output for early integration tests. |
 | Frontend Chat UI | Surface plans, agent responses and diffs | Next.js 14 application with React Server Components, styled layout, and REST calls to backend. |
 | Infrastructure | Make it easy to run locally and in CI | Docker image for backend, docker-compose for local orchestration, GitHub Actions for testing, Terraform placeholders for cloud rollout. |


### PR DESCRIPTION
### Motivation
- Make the backend runnable on Python 3.10 where `enum.StrEnum` is not available to avoid import-time crashes. 
- Align package metadata and documentation with the broader support target so local development and CI can use Python 3.10+. 

### Description
- Add a safe `StrEnum` import with a Python-3.10-compatible fallback `class StrEnum(str, Enum)` in `backend/orchestrator/service.py` so code using `StrEnum` works on older Python versions. 
- Lower backend package Python requirement from `>=3.11` to `>=3.10` in `backend/pyproject.toml`. 
- Update user-facing docs to reflect Python 3.10+ support in `README.md` and `docs/architecture/initial_architecture.md`. 
- Adjust the DevOps agent fallback message in `backend/agents/devops/agent.py` to reference a `Python 3.10+` image instead of hardcoding `3.11`. 

### Testing
- Ran the backend test suite with `PYTHONPATH=/workspace/autodev pytest backend/tests` and all tests passed (`3 passed`). 
- Verified enum usage by importing and printing `RunType`, `RunStatus`, and `StepStatus` from `backend.orchestrator.service` and observed expected outputs. 
- Exercised the FastAPI health endpoint using `TestClient` and confirmed it returned `{'status': 'ok'}`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfec146c10832a950ea4216a30f48e)