### PR TITLE
Publish typed agent metadata contracts and validation with /agents/contracts API

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -19,7 +19,7 @@ Build an open source control plane for software engineering agents that can help
 
 Instead of acting like a black-box chatbot that emits code snippets, AutoDev Architect aims to become an **auditable engineering workflow system** that combines planning, code intelligence, patching, validation, and human approval.
 
-The current implementation already includes a bootstrap durable control plane, persisted workflow-step history, configurable stub/OpenAI agent execution, a persisted runtime configuration layer for LLM and repository/workspace selection, and a first repository-context retrieval API for ranked file discovery.
+The current implementation already includes a bootstrap durable control plane, persisted workflow-step history, configurable stub/OpenAI agent execution, a persisted runtime configuration layer for LLM and repository/workspace selection, a first repository-context retrieval API for ranked file discovery, and published typed agent metadata contracts for downstream machine-readable consumers.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The current codebase provides a functional early platform slice with:
 - agent abstraction layer;
 - stub/fallback LLM integration;
 - simple Next.js control-center interface with runtime configuration for LLM and repository selection;
+- typed agent metadata contracts published via the API for machine-readable downstream/UI consumption;
 - local install script, Docker Compose stack, and initial CI/Terraform placeholders.
 
 The documentation in this repository defines the path from prototype to a complete platform.

--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -2,17 +2,19 @@
 
 from .analyzer import AnalyzerAgent
 from .architect import ArchitectAgent
+from .base import Agent, AgentContext, AgentResult, LangChainAgent
 from .coder import CoderAgent
+from .contracts import AGENT_METADATA_MODELS
 from .devops import DevOpsAgent
 from .navigator import NavigatorAgent
 from .planner import PlannerAgent
 from .validator import ValidatorAgent
-from .base import Agent, AgentContext, AgentResult, LangChainAgent
 
 __all__ = [
     "Agent",
     "AgentContext",
     "AgentResult",
+    "AGENT_METADATA_MODELS",
     "LangChainAgent",
     "AnalyzerAgent",
     "ArchitectAgent",

--- a/backend/agents/analyzer/agent.py
+++ b/backend/agents/analyzer/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from langchain_core.prompts import ChatPromptTemplate
 
 from backend.agents.base import AgentContext, AgentResult, LangChainAgent
+from backend.agents.contracts import AnalyzerOutput
 
 
 class AnalyzerAgent(LangChainAgent):
@@ -32,14 +33,34 @@ class AnalyzerAgent(LangChainAgent):
             ]
         )
 
+    def metadata_model(self):
+        return AnalyzerOutput
+
     def fallback_result(self, context: AgentContext) -> AgentResult:
+        impacted_areas = [
+            "backend orchestrator",
+            "runtime configuration",
+            "repository intelligence",
+        ]
+        risks = [
+            "Machine-readable outputs are still lightly typed in several agents",
+            "UI rendering cannot yet rely on published agent contracts",
+        ]
+        next_actions = [
+            "Add typed metadata contracts for every agent result",
+            "Publish contract schemas through the API for UI consumption",
+            "Extend tests to cover metadata validation and regressions",
+        ]
         summary = (
-            "Analyzer Agent evaluated the request and suggests focusing on backend,"
-            " frontend, and infrastructure scaffolding to unblock subsequent work."
+            "Analyzer Agent evaluated the request and recommends finishing the "
+            "structured-output slice so downstream workflows can depend on "
+            "validated machine-readable artifacts."
         )
         metadata = {
-            "goal": context.goal,
-            "history_count": len(context.history),
+            "summary": summary,
+            "impacted_areas": impacted_areas,
+            "risks": risks,
+            "next_actions": next_actions,
         }
         return AgentResult(content=summary, metadata=metadata)
 

--- a/backend/agents/architect/agent.py
+++ b/backend/agents/architect/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from langchain_core.prompts import ChatPromptTemplate
 
 from backend.agents.base import AgentContext, AgentResult, LangChainAgent
+from backend.agents.contracts import ArchitectOutput
 
 
 class ArchitectAgent(LangChainAgent):
@@ -37,23 +38,34 @@ class ArchitectAgent(LangChainAgent):
         inputs["plan"] = "\n".join(f"- {step}" for step in plan_steps) or "(no plan yet)"
         return inputs
 
+    def metadata_model(self):
+        return ArchitectOutput
+
     def fallback_result(self, context: AgentContext) -> AgentResult:
         architecture = {
             "backend": {
-                "framework": "FastAPI",
-                "modules": ["orchestrator", "agents", "api"],
+                "summary": "Keep workflow coordination and API contracts in the FastAPI control plane.",
+                "decisions": [
+                    "Persist orchestrator state outside prompt text",
+                    "Validate agent metadata before sharing it downstream",
+                ],
             },
             "frontend": {
-                "framework": "Next.js",
-                "features": ["chat", "plan viewer", "diff inspector"],
+                "summary": "Render agent results from typed contracts instead of ad-hoc metadata.",
+                "decisions": [
+                    "Use published JSON schemas to drive future UI components",
+                ],
             },
             "infrastructure": {
-                "docker": True,
-                "ci": "GitHub Actions",
+                "summary": "Preserve the self-hostable bootstrap path while contracts mature.",
+                "decisions": [
+                    "Keep the current file-backed configuration and SQLite bootstrap store",
+                    "Prepare the API surface for later PostgreSQL and Redis upgrades",
+                ],
             },
         }
         description = "; ".join(
-            f"{section}: {details}" for section, details in architecture.items()
+            f"{section}: {details['summary']}" for section, details in architecture.items()
         )
         return AgentResult(content=f"Architecture proposal -> {description}", metadata=architecture)
 

--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Mapping, Protocol
+from typing import Any, Dict, Iterable, List, Mapping, Protocol, Type
+
+from pydantic import BaseModel, ValidationError
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import BaseMessage
@@ -106,8 +108,25 @@ class LangChainAgent(ABC):
 
         return fallback.metadata
 
+    def metadata_model(self) -> Type[BaseModel] | None:
+        """Return the Pydantic model used to validate metadata, when defined."""
+
+        return None
+
+    def validate_metadata(self, metadata: Mapping[str, Any]) -> Dict[str, Any]:
+        """Normalize metadata through a typed contract when available."""
+
+        model = self.metadata_model()
+        if model is None:
+            return dict(metadata)
+
+        validated = model.model_validate(metadata)
+        return validated.model_dump()
+
     def run(self, context: AgentContext) -> AgentResult:
         fallback = self.fallback_result(context)
+        fallback_metadata = self._safe_validate_metadata(fallback.metadata, fallback.metadata)
+        fallback = AgentResult(content=fallback.content, metadata=fallback_metadata)
 
         if not is_configured_model(self._model):
             return fallback
@@ -122,7 +141,24 @@ class LangChainAgent(ABC):
 
         content = self._extract_content(response)
         metadata = self.build_metadata(context, fallback, content)
-        return AgentResult(content=content, metadata=metadata)
+        validated_metadata = self._safe_validate_metadata(metadata, fallback.metadata)
+        return AgentResult(content=content, metadata=validated_metadata)
+
+    def _safe_validate_metadata(
+        self,
+        metadata: Mapping[str, Any],
+        fallback_metadata: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        try:
+            return self.validate_metadata(metadata)
+        except ValidationError:
+            try:
+                return self.validate_metadata(fallback_metadata)
+            except ValidationError:
+                model = self.metadata_model()
+                if model is None:
+                    return dict(fallback_metadata)
+                return model.model_validate({}).model_dump()
 
     def _render_history(self, history: Iterable[Dict[str, str]]) -> str:
         lines = [f"{entry.get('role', 'unknown')}: {entry.get('content', '')}" for entry in history]

--- a/backend/agents/coder/agent.py
+++ b/backend/agents/coder/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from langchain_core.prompts import ChatPromptTemplate
 
 from backend.agents.base import AgentContext, AgentResult, LangChainAgent
+from backend.agents.contracts import CoderOutput
 
 
 class CoderAgent(LangChainAgent):
@@ -36,16 +37,30 @@ class CoderAgent(LangChainAgent):
         inputs["plan"] = "\n".join(f"- {step}" for step in plan_steps) or "(no plan yet)"
         return inputs
 
+    def metadata_model(self):
+        return CoderOutput
+
     def fallback_result(self, context: AgentContext) -> AgentResult:
-        plan_steps = context.artifacts.get("planner", {}).get("steps", [])
         coding_tasks = [
-            "Implement FastAPI orchestrator endpoints",
-            "Create shared agent abstractions and stubs",
-            "Develop chat UI components in Next.js",
-            "Author automated tests for orchestrator logic",
+            {"component": "backend/api", "task": "Expose agent contract schemas through a typed API endpoint"},
+            {"component": "backend/agents", "task": "Validate agent metadata against Pydantic contracts"},
+            {"component": "tests/backend", "task": "Cover schema publishing and metadata validation behavior"},
+            {"component": "docs", "task": "Document the structured-output slice and roadmap progress"},
         ]
-        metadata = {"plan_steps": plan_steps, "coding_tasks": coding_tasks}
-        description = "\n".join(f"- {task}" for task in coding_tasks)
+        metadata = {
+            "coding_tasks": coding_tasks,
+            "test_updates": [
+                "Add orchestrator coverage for contract exposure",
+                "Assert API returns the expected schema documents",
+            ],
+            "touched_components": [
+                "backend/api",
+                "backend/agents",
+                "tests/backend",
+                "docs",
+            ],
+        }
+        description = "\n".join(f"- {item['component']}: {item['task']}" for item in coding_tasks)
         return AgentResult(content=f"Coding tasks:\n{description}", metadata=metadata)
 
 

--- a/backend/agents/contracts.py
+++ b/backend/agents/contracts.py
@@ -1,0 +1,112 @@
+"""Typed contracts for machine-readable agent metadata."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class PlannerOutput(BaseModel):
+    """Structured planning steps shared with downstream agents."""
+
+    steps: List[str] = Field(default_factory=list)
+
+
+class NavigatorCandidateFile(BaseModel):
+    """Structured repository file match emitted by the navigator."""
+
+    path: str
+    score: int
+    reasons: List[str] = Field(default_factory=list)
+
+
+class NavigatorOutput(BaseModel):
+    """Repository context contract used for downstream routing."""
+
+    query: str = ""
+    root: str = ""
+    total_files: int = 0
+    top_directories: List[str] = Field(default_factory=list)
+    candidate_files: List[NavigatorCandidateFile] = Field(default_factory=list)
+    inventory_sample: List[str] = Field(default_factory=list)
+    matched_terms: List[str] = Field(default_factory=list)
+
+
+class AnalyzerOutput(BaseModel):
+    """Change analysis contract used to focus implementation."""
+
+    summary: str = ""
+    impacted_areas: List[str] = Field(default_factory=list)
+    risks: List[str] = Field(default_factory=list)
+    next_actions: List[str] = Field(default_factory=list)
+
+
+class ArchitectSection(BaseModel):
+    """Named architecture section with concise design bullets."""
+
+    summary: str = ""
+    decisions: List[str] = Field(default_factory=list)
+
+
+class ArchitectOutput(BaseModel):
+    """High-level architecture guidance for execution agents."""
+
+    backend: ArchitectSection = Field(default_factory=ArchitectSection)
+    frontend: ArchitectSection = Field(default_factory=ArchitectSection)
+    infrastructure: ArchitectSection = Field(default_factory=ArchitectSection)
+
+
+class CodingTask(BaseModel):
+    """Single implementation task produced by the coder."""
+
+    component: str
+    task: str
+
+
+class CoderOutput(BaseModel):
+    """Code-oriented work breakdown for patch generation."""
+
+    coding_tasks: List[CodingTask] = Field(default_factory=list)
+    test_updates: List[str] = Field(default_factory=list)
+    touched_components: List[str] = Field(default_factory=list)
+
+
+class DevOpsOutput(BaseModel):
+    """Automation and delivery tasks for the platform."""
+
+    deliverables: Dict[str, str] = Field(default_factory=dict)
+    operational_checks: List[str] = Field(default_factory=list)
+
+
+class ValidatorOutput(BaseModel):
+    """Executable validation guidance captured in structured form."""
+
+    validation_steps: List[str] = Field(default_factory=list)
+    success_criteria: List[str] = Field(default_factory=list)
+
+
+AGENT_METADATA_MODELS = {
+    "planner": PlannerOutput,
+    "navigator": NavigatorOutput,
+    "analyzer": AnalyzerOutput,
+    "architect": ArchitectOutput,
+    "coder": CoderOutput,
+    "devops": DevOpsOutput,
+    "validator": ValidatorOutput,
+}
+
+
+__all__ = [
+    "AGENT_METADATA_MODELS",
+    "AnalyzerOutput",
+    "ArchitectOutput",
+    "ArchitectSection",
+    "CoderOutput",
+    "CodingTask",
+    "DevOpsOutput",
+    "NavigatorCandidateFile",
+    "NavigatorOutput",
+    "PlannerOutput",
+    "ValidatorOutput",
+]

--- a/backend/agents/devops/agent.py
+++ b/backend/agents/devops/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from langchain_core.prompts import ChatPromptTemplate
 
 from backend.agents.base import AgentContext, AgentResult, LangChainAgent
+from backend.agents.contracts import DevOpsOutput
 
 
 class DevOpsAgent(LangChainAgent):
@@ -30,14 +31,24 @@ class DevOpsAgent(LangChainAgent):
             ]
         )
 
+    def metadata_model(self):
+        return DevOpsOutput
+
     def fallback_result(self, context: AgentContext) -> AgentResult:
         deliverables = {
-            "docker": "Create Python 3.10+ image exposing the FastAPI app",
-            "ci": "Configure GitHub Actions workflow running tests and lint",
-            "infrastructure": "Prepare Terraform placeholder for future cloud resources",
+            "docker": "Keep the FastAPI service runnable in the existing self-hosted container workflow",
+            "ci": "Run backend tests that verify structured-output contracts remain stable",
+            "configuration": "Preserve the local file-based runtime config path for OSS deployments",
+        }
+        metadata = {
+            "deliverables": deliverables,
+            "operational_checks": [
+                "Verify the API exposes agent contract schemas",
+                "Ensure deterministic fallback agents still emit valid metadata",
+            ],
         }
         description = "\n".join(f"- {key}: {value}" for key, value in deliverables.items())
-        return AgentResult(content=f"DevOps tasks:\n{description}", metadata=deliverables)
+        return AgentResult(content=f"DevOps tasks:\n{description}", metadata=metadata)
 
 
 __all__ = ["DevOpsAgent"]

--- a/backend/agents/navigator/agent.py
+++ b/backend/agents/navigator/agent.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from langchain_core.prompts import ChatPromptTemplate
 
 from backend.agents.base import AgentContext, AgentResult, LangChainAgent
+from backend.agents.contracts import NavigatorOutput
 from backend.repository import RepositoryIntelligenceService
 
 
@@ -48,6 +49,9 @@ class NavigatorAgent(LangChainAgent):
         inputs["candidate_files"] = self._render_candidate_files(repository_context)
         inputs["inventory_sample"] = "\n".join(repository_context.inventory_sample) or "(empty)"
         return inputs
+
+    def metadata_model(self):
+        return NavigatorOutput
 
     def fallback_result(self, context: AgentContext) -> AgentResult:
         repository_context = self._build_repository_context(context)

--- a/backend/agents/planner/agent.py
+++ b/backend/agents/planner/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from langchain_core.prompts import ChatPromptTemplate
 
 from backend.agents.base import AgentContext, AgentResult, LangChainAgent
+from backend.agents.contracts import PlannerOutput
 
 
 class PlannerAgent(LangChainAgent):
@@ -28,6 +29,9 @@ class PlannerAgent(LangChainAgent):
                 ),
             ]
         )
+
+    def metadata_model(self):
+        return PlannerOutput
 
     def fallback_result(self, context: AgentContext) -> AgentResult:
         goal = context.goal or "Refine project requirements"

--- a/backend/agents/validator/agent.py
+++ b/backend/agents/validator/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from langchain_core.prompts import ChatPromptTemplate
 
 from backend.agents.base import AgentContext, AgentResult, LangChainAgent
+from backend.agents.contracts import ValidatorOutput
 
 
 class ValidatorAgent(LangChainAgent):
@@ -30,13 +31,22 @@ class ValidatorAgent(LangChainAgent):
             ]
         )
 
+    def metadata_model(self):
+        return ValidatorOutput
+
     def fallback_result(self, context: AgentContext) -> AgentResult:
         validation_steps = [
             "Run pytest for backend modules",
-            "Execute frontend lint and type checks",
-            "Perform security scanning before deployment",
+            "Exercise the /agents/contracts endpoint through API tests",
+            "Confirm fallback agents emit schema-valid metadata without a live model",
         ]
-        metadata = {"validation_steps": validation_steps}
+        metadata = {
+            "validation_steps": validation_steps,
+            "success_criteria": [
+                "Every agent result metadata payload validates against its published contract",
+                "The API can return JSON schemas for UI-driven rendering",
+            ],
+        }
         description = "\n".join(f"- {step}" for step in validation_steps)
         return AgentResult(content=f"Validation steps:\n{description}", metadata=metadata)
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -125,6 +125,10 @@ class RuntimeConfigUpdateRequest(BaseModel):
     config: RuntimeConfig
 
 
+class AgentContractsResponse(BaseModel):
+    contracts: Dict[str, Dict[str, Any]]
+
+
 @lru_cache(maxsize=1)
 def get_orchestrator() -> OrchestratorService:
     config_service = get_runtime_config_service()
@@ -189,6 +193,13 @@ def update_runtime_config(
     get_repository_intelligence.cache_clear()
     document = config_service.load_document()
     return RuntimeConfigResponse(config=document.config, instructions=document.instructions)
+
+
+@app.get("/agents/contracts", response_model=AgentContractsResponse, tags=["agents"])
+def get_agent_contracts(
+    orchestrator: OrchestratorService = Depends(get_orchestrator),
+) -> AgentContractsResponse:
+    return AgentContractsResponse(contracts=orchestrator.describe_agent_contracts())
 
 
 @app.post("/plan", response_model=PlanResponse, tags=["planning"])

--- a/backend/orchestrator/service.py
+++ b/backend/orchestrator/service.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 from langgraph.graph import END, StateGraph
 
 from backend.agents import (
+    AGENT_METADATA_MODELS,
     Agent,
     AgentContext,
     AgentResult,
@@ -214,6 +215,14 @@ class OrchestratorService:
             self._agents.update(agents)
         self._store = store or get_store()
         self._graph = self._compile_graph()
+
+    def describe_agent_contracts(self) -> Dict[str, Dict[str, Any]]:
+        """Return JSON-schema contracts for machine-readable agent metadata."""
+
+        return {
+            agent_name: model.model_json_schema()
+            for agent_name, model in AGENT_METADATA_MODELS.items()
+        }
 
     def create_plan(self, goal: str) -> PlanSession:
         planner: PlannerAgent = self._require_agent("planner")  # type: ignore[assignment]

--- a/docs/implementation/implementation_strategy.md
+++ b/docs/implementation/implementation_strategy.md
@@ -112,6 +112,11 @@ Use layered retrieval:
 - error handling for malformed outputs;
 - UI rendering based on structured results.
 
+Current functional slice in this repository:
+- every built-in agent now validates its machine-readable metadata against a Pydantic contract;
+- `GET /agents/contracts` publishes JSON Schema documents for downstream UI or automation consumers;
+- malformed metadata falls back to the deterministic contract-valid payload so orchestrations remain machine-readable even without a live model.
+
 ### Example output domains
 - planner: steps, assumptions, risks, acceptance criteria;
 - navigator: candidate files, symbols, repository regions;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,6 +47,7 @@ Current implementation status:
 - run records now distinguish workflow types such as documentation, validation, devops, and existing-repository change;
 - each run now persists ordered workflow steps, creating a bridge from the bootstrap durable control plane to a fuller state machine;
 - a first repository-intelligence slice now exposes structured file inventory and ranked candidate-file retrieval via the navigator and `GET /repository/context`;
+- typed metadata contracts are now published for every built-in agent via `GET /agents/contracts`, with fallback validation keeping machine-readable artifacts well-formed;
 - tree-sitter indexing, deeper retrieval, and repository metadata storage remain the next major capability gap.
 
 Goals:

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -28,6 +28,16 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     reset_store_cache()
 
 
+def test_agent_contract_endpoint(client: TestClient) -> None:
+    response = client.get("/agents/contracts")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "planner" in payload["contracts"]
+    assert payload["contracts"]["planner"]["properties"]["steps"]["type"] == "array"
+    assert "validator" in payload["contracts"]
+
+
 def test_session_and_run_endpoints(client: TestClient) -> None:
     plan_response = client.post("/plan", json={"goal": "Ship durable control plane"})
     assert plan_response.status_code == 200

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from backend.agents import AgentResult
+from backend.agents.planner.agent import PlannerAgent
 from backend.orchestrator.service import OrchestratorService
 from backend.persistence.database import DurableStore, reset_store_cache
 
@@ -97,6 +98,15 @@ def test_run_type_inference_uses_workflow_categories(orchestrator_service: Orche
     assert result.run_type == "documentation_update"
 
 
+def test_agent_contracts_are_exposed(orchestrator_service: OrchestratorService) -> None:
+    contracts = orchestrator_service.describe_agent_contracts()
+
+    assert "planner" in contracts
+    assert contracts["planner"]["properties"]["steps"]["type"] == "array"
+    assert "navigator" in contracts
+    assert contracts["navigator"]["properties"]["candidate_files"]["type"] == "array"
+
+
 class PlannerWithoutMetadata:
     """Planner stub that omits structured step metadata."""
 
@@ -112,6 +122,28 @@ class PlannerWithoutMetadata:
             ]
         )
         return AgentResult(content=content, metadata={})
+
+
+class InvalidPlannerFallbackAgent(PlannerAgent):
+    """Planner variant with malformed fallback metadata to exercise validation."""
+
+    def fallback_result(self, _) -> AgentResult:  # pragma: no cover - simple stub
+        return AgentResult(content="Broken planner output", metadata={"steps": "not-a-list"})
+
+
+def test_agent_metadata_validation_falls_back_to_contract_valid_payload(
+    orchestrator_service: OrchestratorService,
+) -> None:
+    service = OrchestratorService(
+        agents={"planner": InvalidPlannerFallbackAgent()},
+        store=orchestrator_service._store,
+    )
+
+    session = service.create_plan("Validate metadata")
+
+    assert session.plan == []
+    stored_session = service.get_session(session.session_id)
+    assert stored_session.plan == session.plan
 
 
 def test_create_plan_fallback_filters_non_list_lines(orchestrator_service: OrchestratorService) -> None:


### PR DESCRIPTION
### Motivation
- Provide machine-readable, validated agent outputs so downstream UI and automation can rely on structured metadata instead of ad-hoc blobs. 
- Improve robustness by validating agent metadata and falling back to deterministic contract-safe payloads when LLM-generated metadata is malformed. 
- Surface schema documents via the API so UIs or other consumers can render and act on agent outputs deterministically.

### Description
- Add Pydantic contracts for built-in agents in `backend/agents/contracts.py` and expose them via `AGENT_METADATA_MODELS`. 
- Extend the LangChain agent base to support `metadata_model()` and runtime validation (`LangChainAgent.validate_metadata` and `_safe_validate_metadata`), ensuring fallback metadata is contract-safe. 
- Update built-in agents to declare `metadata_model()` and to emit richer, contract-shaped fallback metadata. 
- Add `OrchestratorService.describe_agent_contracts()` and a new API endpoint `GET /agents/contracts` that returns JSON Schema documents for each agent; update docs and tests to cover the new surface.

### Testing
- Ran targeted backend tests with `pytest -q tests/backend/test_orchestrator.py tests/backend/test_api.py`, which passed (`10 passed`). 
- Performed a syntax/compile sanity check with the in-repo Python compile step (`python - <<'PY' ... compile(...) ... PY`), which completed successfully. 
- Added API and orchestrator unit tests asserting contract publication and metadata validation fallbacks, and those tests succeeded in the CI-local run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfee7aacf0832a9459a52ba84eeb82)