### PR TITLE
Add user-scoped AgentContext and Responder agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The current codebase provides a functional early platform slice with:
 - simple Next.js control-center interface with runtime configuration for LLM and repository selection;
 - dedicated frontend configuration workspace plus dashboard navigation between execution and config flows;
 - post-analysis execution-plan generation that expands agent artifacts into ordered tasks and supports sequential execution runs;
+- explicit separation between agent behavior instructions and the latest user request, with a responder agent that compiles the final user-facing answer from specialist outputs;
 - typed agent metadata contracts published via the API for machine-readable downstream/UI consumption;
 - local install script, Docker Compose stack, and initial CI/Terraform placeholders.
 

--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -8,6 +8,7 @@ from .contracts import AGENT_METADATA_MODELS
 from .devops import DevOpsAgent
 from .navigator import NavigatorAgent
 from .planner import PlannerAgent
+from .responder import ResponderAgent
 from .validator import ValidatorAgent
 
 __all__ = [
@@ -22,5 +23,6 @@ __all__ = [
     "DevOpsAgent",
     "NavigatorAgent",
     "PlannerAgent",
+    "ResponderAgent",
     "ValidatorAgent",
 ]

--- a/backend/agents/analyzer/agent.py
+++ b/backend/agents/analyzer/agent.py
@@ -25,6 +25,7 @@ class AnalyzerAgent(LangChainAgent):
                 (
                     "human",
                     "Goal: {goal}\n"
+                    "Current user request: {user_request}\n"
                     "History so far:\n{history}\n"
                     "Shared artifacts:\n{artifacts}\n"
                     "Provide a concise summary of the situation and name the product areas "

--- a/backend/agents/architect/agent.py
+++ b/backend/agents/architect/agent.py
@@ -25,6 +25,7 @@ class ArchitectAgent(LangChainAgent):
                 (
                     "human",
                     "Goal: {goal}\n"
+                    "Current user request: {user_request}\n"
                     "Plan steps:\n{plan}\n"
                     "Known artifacts:\n{artifacts}\n"
                     "Describe the architecture with concise bullets for each domain.",

--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -21,6 +21,7 @@ class AgentContext:
 
     session_id: str
     goal: str | None = None
+    user_request: str | None = None
     history: List[Dict[str, str]] = field(default_factory=list)
     artifacts: Dict[str, Any] = field(default_factory=dict)
 
@@ -32,6 +33,7 @@ class AgentContext:
         return AgentContext(
             session_id=self.session_id,
             goal=self.goal,
+            user_request=self.user_request,
             history=list(self.history),
             artifacts=updated,
         )
@@ -44,6 +46,7 @@ class AgentContext:
         return AgentContext(
             session_id=self.session_id,
             goal=self.goal,
+            user_request=self.user_request,
             history=history,
             artifacts=dict(self.artifacts),
         )
@@ -90,6 +93,7 @@ class LangChainAgent(ABC):
 
         return {
             "goal": context.goal or "",
+            "user_request": context.user_request or context.goal or "",
             "history": self._render_history(context.history),
             "artifacts": self._render_artifacts(context.artifacts),
         }

--- a/backend/agents/coder/agent.py
+++ b/backend/agents/coder/agent.py
@@ -24,6 +24,7 @@ class CoderAgent(LangChainAgent):
                 (
                     "human",
                     "Goal: {goal}\n"
+                    "Current user request: {user_request}\n"
                     "Recent plan:\n{plan}\n"
                     "Available artifacts:\n{artifacts}\n"
                     "List concrete coding tasks grouped by component.",

--- a/backend/agents/contracts.py
+++ b/backend/agents/contracts.py
@@ -86,6 +86,16 @@ class ValidatorOutput(BaseModel):
     success_criteria: List[str] = Field(default_factory=list)
 
 
+class ResponderOutput(BaseModel):
+    """Final response metadata compiled for the user-facing answer."""
+
+    response_mode: str = "answer"
+    summary: str = ""
+    applies_user_request: bool = False
+    source_agents: List[str] = Field(default_factory=list)
+    recommended_actions: List[str] = Field(default_factory=list)
+
+
 AGENT_METADATA_MODELS = {
     "planner": PlannerOutput,
     "navigator": NavigatorOutput,
@@ -94,6 +104,7 @@ AGENT_METADATA_MODELS = {
     "coder": CoderOutput,
     "devops": DevOpsOutput,
     "validator": ValidatorOutput,
+    "responder": ResponderOutput,
 }
 
 
@@ -108,5 +119,6 @@ __all__ = [
     "NavigatorCandidateFile",
     "NavigatorOutput",
     "PlannerOutput",
+    "ResponderOutput",
     "ValidatorOutput",
 ]

--- a/backend/agents/devops/agent.py
+++ b/backend/agents/devops/agent.py
@@ -24,6 +24,7 @@ class DevOpsAgent(LangChainAgent):
                 (
                     "human",
                     "Goal: {goal}\n"
+                    "Current user request: {user_request}\n"
                     "Context:\n{history}\n"
                     "Artifacts:\n{artifacts}\n"
                     "List the core DevOps deliverables with short explanations.",

--- a/backend/agents/navigator/agent.py
+++ b/backend/agents/navigator/agent.py
@@ -32,6 +32,7 @@ class NavigatorAgent(LangChainAgent):
                     "human",
                     "Root path: {root}\n"
                     "User goal: {goal}\n"
+                    "Current user request: {user_request}\n"
                     "Recent history:\n{history}\n"
                     "Top directories: {directories}\n"
                     "Candidate files: {candidate_files}\n"

--- a/backend/agents/planner/agent.py
+++ b/backend/agents/planner/agent.py
@@ -24,6 +24,7 @@ class PlannerAgent(LangChainAgent):
                 (
                     "human",
                     "Goal: {goal}\n"
+                    "Current user request: {user_request}\n"
                     "Conversation so far:\n{history}\n"
                     "Draft a numbered plan with 3-5 steps that other agents can follow.",
                 ),

--- a/backend/agents/responder/__init__.py
+++ b/backend/agents/responder/__init__.py
@@ -1,0 +1,5 @@
+"""Responder agent package."""
+
+from .agent import ResponderAgent
+
+__all__ = ["ResponderAgent"]

--- a/backend/agents/responder/agent.py
+++ b/backend/agents/responder/agent.py
@@ -1,0 +1,90 @@
+"""Responder agent that compiles the final user-facing response."""
+
+from __future__ import annotations
+
+from langchain_core.prompts import ChatPromptTemplate
+
+from backend.agents.base import AgentContext, AgentResult, LangChainAgent
+from backend.agents.contracts import ResponderOutput
+
+
+class ResponderAgent(LangChainAgent):
+    """Compile upstream agent outputs into the final response for the user."""
+
+    name = "responder"
+
+    def build_prompt(self) -> ChatPromptTemplate:
+        return ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "You are the Responder agent. Synthesize the outputs from the specialist "
+                    "agents into the final response for the user. Keep the answer grounded in "
+                    "the current user request, clearly distinguish recommendations from actions, "
+                    "and when the user asked for modifications, describe the concrete changes to apply.",
+                ),
+                (
+                    "human",
+                    "Goal: {goal}\n"
+                    "Current user request: {user_request}\n"
+                    "Conversation so far:\n{history}\n"
+                    "Specialist artifacts:\n{artifacts}\n"
+                    "Produce the final user-facing response.",
+                ),
+            ]
+        )
+
+    def metadata_model(self):
+        return ResponderOutput
+
+    def fallback_result(self, context: AgentContext) -> AgentResult:
+        request = (context.user_request or context.goal or "").strip()
+        requested_application = any(
+            keyword in request.lower()
+            for keyword in ("aplique", "implemente", "modifique", "altere", "corrija", "apply", "implement")
+        )
+        analyzer = context.artifacts.get("analyzer", {})
+        coder = context.artifacts.get("coder", {})
+        validator = context.artifacts.get("validator", {})
+
+        highlights = []
+        if analyzer.get("summary"):
+            highlights.append(analyzer["summary"])
+        for item in coder.get("coding_tasks", [])[:3]:
+            component = item.get("component", "component")
+            task = item.get("task", "")
+            highlights.append(f"{component}: {task}")
+        validation_steps = list(validator.get("validation_steps", []))[:2]
+
+        response_mode = "apply_changes" if requested_application else "answer"
+        intro = (
+            "Os agentes consolidaram um plano de mudança orientado à aplicação das modificações solicitadas."
+            if requested_application
+            else "Os agentes consolidaram a análise dentro do contexto pedido pelo usuário."
+        )
+        summary = request or (context.goal or "Summarize the current execution state")
+        response_lines = [intro]
+        if summary:
+            response_lines.append(f"Solicitação atual: {summary}.")
+        if highlights:
+            response_lines.append("Principais pontos: " + " ".join(f"- {item}" for item in highlights))
+        if validation_steps:
+            response_lines.append(
+                "Validação recomendada: " + " ".join(f"- {step}" for step in validation_steps)
+            )
+
+        metadata = {
+            "response_mode": response_mode,
+            "summary": summary,
+            "applies_user_request": bool(request),
+            "source_agents": [
+                agent_name
+                for agent_name in ("navigator", "analyzer", "architect", "coder", "devops", "validator")
+                if context.artifacts.get(agent_name)
+            ],
+            "recommended_actions": highlights[:4] or validation_steps,
+        }
+        return AgentResult(content="\n".join(response_lines), metadata=metadata)
+
+
+__all__ = ["ResponderAgent"]

--- a/backend/agents/validator/agent.py
+++ b/backend/agents/validator/agent.py
@@ -24,6 +24,7 @@ class ValidatorAgent(LangChainAgent):
                 (
                     "human",
                     "Goal: {goal}\n"
+                    "Current user request: {user_request}\n"
                     "Recent discussion:\n{history}\n"
                     "Artifacts:\n{artifacts}\n"
                     "List concrete validation steps.",

--- a/backend/orchestrator/service.py
+++ b/backend/orchestrator/service.py
@@ -31,6 +31,7 @@ from backend.agents import (
     DevOpsAgent,
     NavigatorAgent,
     PlannerAgent,
+    ResponderAgent,
     ValidatorAgent,
 )
 from backend.persistence import DurableStore, get_store
@@ -220,6 +221,7 @@ class OrchestratorConfig:
         "coder",
         "devops",
         "validator",
+        "responder",
     )
 
 
@@ -261,7 +263,7 @@ class OrchestratorService:
     def create_plan(self, goal: str) -> PlanSession:
         planner: PlannerAgent = self._require_agent("planner")  # type: ignore[assignment]
         session_id = str(uuid4())
-        context = AgentContext(session_id=session_id, goal=goal)
+        context = AgentContext(session_id=session_id, goal=goal, user_request=goal)
         plan_result = planner.run(context)
         plan_steps = self._extract_plan_steps(plan_result)
         status = RunStatus.AWAITING_INPUT
@@ -302,6 +304,7 @@ class OrchestratorService:
         context = AgentContext(
             session_id=session_id,
             goal=session_record["goal"],
+            user_request=message,
             history=[item.to_dict() for item in history] + [user_entry.to_dict()],
             artifacts=dict(session_record["artifacts"] or {}),
         )
@@ -672,6 +675,7 @@ class OrchestratorService:
             "coder": CoderAgent(),
             "devops": DevOpsAgent(),
             "validator": ValidatorAgent(),
+            "responder": ResponderAgent(),
         }
 
     def _compile_graph(self) -> Any:

--- a/backend/tests/test_agent_context_routing.py
+++ b/backend/tests/test_agent_context_routing.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.agents.analyzer.agent import AnalyzerAgent
+from backend.agents.base import AgentContext
+from backend.api.main import app, get_orchestrator
+from backend.orchestrator.service import OrchestratorService
+from backend.persistence import DurableStore
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _build_orchestrator(tmp_path: Path) -> OrchestratorService:
+    _write(tmp_path / "frontend" / "app" / "page.tsx", "export default function Page() { return null; }")
+    _write(tmp_path / "backend" / "api" / "main.py", "from fastapi import FastAPI")
+    store = DurableStore(f"sqlite:///{tmp_path / 'autodev-test.db'}")
+    return OrchestratorService(store=store, project_root=tmp_path)
+
+
+def test_agent_prompts_receive_goal_and_current_user_request_separately() -> None:
+    agent = AnalyzerAgent()
+    context = AgentContext(
+        session_id="session-1",
+        goal="Fortalecer a orquestração multiagente",
+        user_request="Aplique apenas mudanças no backend e responda em português",
+        history=[{"role": "user", "content": "Aplique apenas mudanças no backend e responda em português"}],
+        artifacts={"planner": {"steps": ["Analisar a solicitação"]}},
+    )
+
+    prompt_value = agent.prompt.format_prompt(**agent.prepare_inputs(context))
+    rendered_messages = prompt_value.to_messages()
+    user_prompt = str(rendered_messages[-1].content)
+
+    assert "Goal: Fortalecer a orquestração multiagente" in user_prompt
+    assert "Current user request: Aplique apenas mudanças no backend e responda em português" in user_prompt
+
+
+def test_orchestrator_appends_responder_output_grounded_in_latest_user_request(tmp_path: Path) -> None:
+    orchestrator = _build_orchestrator(tmp_path)
+    session = orchestrator.create_plan("Melhorar a colaboração dos agentes")
+
+    message = "Aplique modificações no backend para manter cada agente no contexto solicitado"
+    run = orchestrator.handle_message(session.session_id, message)
+
+    assert run.results[-1].agent == "responder"
+    assert run.results[-1].metadata["response_mode"] == "apply_changes"
+    assert run.results[-1].metadata["summary"] == message
+    assert run.history[-1].role == "responder"
+    assert "Solicitação atual" in run.results[-1].content
+
+
+def test_agent_contracts_endpoint_exposes_responder_schema(tmp_path: Path) -> None:
+    orchestrator = _build_orchestrator(tmp_path)
+    app.dependency_overrides[get_orchestrator] = lambda: orchestrator
+    client = TestClient(app)
+
+    response = client.get("/agents/contracts")
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "responder" in payload["contracts"]

--- a/docs/implementation/agent_spec.md
+++ b/docs/implementation/agent_spec.md
@@ -9,6 +9,7 @@ This document defines the target behavior, responsibilities, and structured outp
 All agents should:
 
 - receive structured context;
+- keep behavioral instructions in the system prompt and the latest task/request in user-scoped prompt fields;
 - produce both narrative and machine-readable output;
 - avoid making side effects directly unless explicitly designed to do so;
 - preserve traceability between input, reasoning summary, and output;
@@ -144,6 +145,19 @@ Define and execute validation.
 - logs and artifact references
 - failure classification
 - rework recommendations
+
+---
+
+## Responder Agent
+
+### Responsibility
+Compile the specialist-agent outputs into the final response for the user while staying grounded in the latest request.
+
+### Outputs
+- final response text
+- response mode (`answer` vs `apply_changes`)
+- source agents used in the synthesis
+- recommended next actions
 
 ---
 


### PR DESCRIPTION
### Motivation
- Make the latest user request explicit and separate from the long-lived session `goal` so specialist agents can keep system-level behavior instructions in the system prompt and consume the concrete task the user asked for as a user-scoped field.
- Provide a dedicated finalizer that synthesizes specialist agent outputs into a single, user-grounded response and can classify whether the user asked to apply changes.
- Surface the final-response contract via the same typed metadata mechanism so UIs and automation can consume it reliably.

### Description
- Add a `user_request` field to `AgentContext` and include it in `LangChainAgent.prepare_inputs` so prompts receive both `goal` and `user_request` separately (changes in `backend/agents/base.py`).
- Update specialist agent prompts (Planner, Navigator, Analyzer, Architect, Coder, DevOps, Validator) to accept `Current user request: {user_request}` in the human prompt template.
- Introduce `ResponderAgent` that synthesizes upstream artifacts into a final user-facing answer and publish its typed contract `ResponderOutput` in `AGENT_METADATA_MODELS` (new files under `backend/agents/responder/*` and updated `backend/agents/contracts.py`).
- Wire the responder into the orchestrator by passing `user_request` when creating plans and handling chat messages and by appending `responder` to the default `agent_order` and agent registry (`backend/orchestrator/service.py`).
- Document the prompt separation and responder role in `README.md` and `docs/implementation/agent_spec.md`, and add `backend/tests/test_agent_context_routing.py` to validate prompt rendering, responder execution, and schema exposure.

### Testing
- Ran `PYTHONPATH=/workspace/autodev pytest backend/tests/test_agent_context_routing.py backend/tests/test_execution_plan.py` and all tests passed (5 passed).
- Ran `python -m compileall backend` to validate byte-compilation of the backend and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff43903a0832ab0cd440585432448)