### PR TITLE
Add 0.6 OSS slice: CLI, Ollama local-model support, docs and tests

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -19,7 +19,7 @@ Build an open source control plane for software engineering agents that can help
 
 Instead of acting like a black-box chatbot that emits code snippets, AutoDev Architect aims to become an **auditable engineering workflow system** that combines planning, code intelligence, patching, validation, and human approval.
 
-The current implementation already includes a bootstrap durable control plane, persisted workflow-step history, configurable stub/OpenAI agent execution, a persisted runtime configuration layer for LLM and repository/workspace selection, a dedicated frontend config workspace, a first repository-context retrieval API for ranked file discovery, post-analysis execution-plan generation with sequential task execution, and published typed agent metadata contracts for downstream machine-readable consumers.
+The current implementation already includes a bootstrap durable control plane, persisted workflow-step history, configurable stub/OpenAI/Ollama agent execution, a persisted runtime configuration layer for LLM and repository/workspace selection, a dedicated frontend config workspace, a first repository-context retrieval API for ranked file discovery, post-analysis execution-plan generation with sequential task execution, a structured local CLI for operators, and published typed agent metadata contracts for downstream machine-readable consumers.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The current codebase provides a functional early platform slice with:
 - explicit run typing plus persisted workflow-step history for each execution;
 - agent abstraction layer;
 - stub/fallback LLM integration;
+- first-class local-model configuration via `ollama` using an OpenAI-compatible local endpoint;
+- structured local CLI support for config inspection, planning, run execution, and repository-context inspection;
 - simple Next.js control-center interface with runtime configuration for LLM and repository selection;
 - dedicated frontend configuration workspace plus dashboard navigation between execution and config flows;
 - post-analysis execution-plan generation that expands agent artifacts into ordered tasks and supports sequential execution runs;
@@ -153,6 +155,7 @@ For rationale, read [`docs/architecture/stack_decisions.md`](docs/architecture/s
 
 ### Implementation
 - [`docs/implementation/implementation_strategy.md`](docs/implementation/implementation_strategy.md): detailed implementation strategy.
+- [`docs/implementation/self_hosting_oss.md`](docs/implementation/self_hosting_oss.md): OSS/self-hosted setup paths for stub, Ollama, and hybrid modes.
 - [`docs/implementation/agent_spec.md`](docs/implementation/agent_spec.md): role definitions, contracts, and expected outputs for agents.
 - [`docs/implementation/data_model.md`](docs/implementation/data_model.md): persistent data model and storage guidance.
 
@@ -245,8 +248,32 @@ This repository is still in the transition from prototype to platform. The new d
 4. Configure the agent API / LLM provider:
    - keep `LLM_PROVIDER=stub` for fully local deterministic fallback behavior; or
    - set `LLM_PROVIDER=openai` and fill `OPENAI_API_KEY`, plus optional `OPENAI_MODEL`, `OPENAI_BASE_URL`, and `OPENAI_TEMPERATURE`.
+   - set `LLM_PROVIDER=ollama` for a local-model path and optionally override `OLLAMA_BASE_URL` (defaults to `http://localhost:11434/v1`).
 5. Start the backend with `source .venv/bin/activate && uvicorn backend.api.main:app --reload`.
 6. Start the frontend with `cd frontend && npm run dev`.
+7. Optionally use the structured CLI:
+   - `python -m backend.cli config show`
+   - `python -m backend.cli plan "Improve local OSS workflow"`
+   - `python -m backend.cli repository context --query "config cli ollama"`
+
+### OSS self-hosting quick paths
+
+#### Fully local deterministic mode
+- Backend: `LLM_PROVIDER=stub uvicorn backend.api.main:app --reload`
+- Frontend: `cd frontend && npm run dev`
+- CLI: `python -m backend.cli config show --format env`
+
+#### Local-model mode with Ollama
+1. Run Ollama locally and expose its OpenAI-compatible endpoint.
+2. Set `LLM_PROVIDER=ollama`.
+3. Set `OPENAI_MODEL` or save the model name in `autodev.config.json` through the UI/CLI.
+4. Optionally set `OLLAMA_BASE_URL` if your local gateway is not `http://localhost:11434/v1`.
+
+#### Docker Compose bootstrap
+- Start the current stack with `docker compose -f infrastructure/docker-compose.yml up --build`.
+- The compose file keeps the backend on the open-source `stub` path by default so the platform can boot without paid infrastructure.
+
+For a fuller operator checklist, read [`docs/implementation/self_hosting_oss.md`](docs/implementation/self_hosting_oss.md).
 
 ### Runtime configuration center
 

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -1,0 +1,200 @@
+"""Structured CLI for local AutoDev Architect operations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+from backend.config import RuntimeConfigService
+from backend.llm.factory import get_chat_model
+from backend.orchestrator.service import OrchestratorService
+from backend.persistence.database import reset_store_cache
+from backend.repository import RepositoryIntelligenceService
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="autodev",
+        description="CLI estruturada para configurar e operar o AutoDev Architect localmente.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    config_parser = subparsers.add_parser("config", help="Exibir ou atualizar a configuração runtime")
+    config_subparsers = config_parser.add_subparsers(dest="config_command", required=True)
+
+    config_show_parser = config_subparsers.add_parser("show", help="Renderiza a configuração atual")
+    config_show_parser.add_argument(
+        "--format",
+        choices=("json", "env"),
+        default="json",
+        help="Formato de saída estruturada.",
+    )
+    config_show_parser.set_defaults(handler=_handle_config_show)
+
+    config_set_parser = config_subparsers.add_parser("set", help="Atualiza campos da configuração")
+    config_set_parser.add_argument("--provider")
+    config_set_parser.add_argument("--model")
+    config_set_parser.add_argument("--base-url")
+    config_set_parser.add_argument("--temperature", type=float)
+    config_set_parser.add_argument("--api-key")
+    config_set_parser.add_argument("--project-root")
+    config_set_parser.add_argument("--repository-label")
+    config_set_parser.add_argument("--default-goal")
+    config_set_parser.set_defaults(handler=_handle_config_set)
+
+    sessions_parser = subparsers.add_parser("sessions", help="Operações de sessão")
+    sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_command", required=True)
+    sessions_list_parser = sessions_subparsers.add_parser("list", help="Lista sessões persistidas")
+    sessions_list_parser.set_defaults(handler=_handle_sessions_list)
+
+    plan_parser = subparsers.add_parser("plan", help="Cria uma nova sessão de planejamento")
+    plan_parser.add_argument("goal", help="Objetivo principal da sessão")
+    plan_parser.set_defaults(handler=_handle_plan_create)
+
+    run_parser = subparsers.add_parser("run", help="Envia mensagens ou executa o plano derivado")
+    run_subparsers = run_parser.add_subparsers(dest="run_command", required=True)
+
+    run_message_parser = run_subparsers.add_parser("message", help="Executa um ciclo completo de agentes")
+    run_message_parser.add_argument("session_id")
+    run_message_parser.add_argument("message")
+    run_message_parser.set_defaults(handler=_handle_run_message)
+
+    run_execute_parser = run_subparsers.add_parser("execute-plan", help="Executa o backlog derivado")
+    run_execute_parser.add_argument("session_id")
+    run_execute_parser.set_defaults(handler=_handle_execute_plan)
+
+    repository_parser = subparsers.add_parser("repository", help="Contexto estruturado do repositório")
+    repository_subparsers = repository_parser.add_subparsers(dest="repository_command", required=True)
+    repository_context_parser = repository_subparsers.add_parser(
+        "context",
+        help="Retorna o contexto ranqueado do repositório ativo",
+    )
+    repository_context_parser.add_argument("--query", default="", help="Consulta lexical inicial")
+    repository_context_parser.add_argument("--limit", type=int, default=6)
+    repository_context_parser.set_defaults(handler=_handle_repository_context)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.handler(args))
+
+
+def _build_runtime_services() -> tuple[RuntimeConfigService, OrchestratorService, RepositoryIntelligenceService]:
+    config_service = RuntimeConfigService()
+    runtime_config = config_service.apply_to_environment()
+    get_chat_model.cache_clear()
+    reset_store_cache()
+    project_root = Path(runtime_config.repository.project_root)
+    orchestrator = OrchestratorService(project_root=project_root)
+    repository_service = RepositoryIntelligenceService(project_root=project_root)
+    return config_service, orchestrator, repository_service
+
+
+def _handle_config_show(args: argparse.Namespace) -> int:
+    config_service, _, _ = _build_runtime_services()
+    document = config_service.load_document()
+    if args.format == "env":
+        print(document.instructions.env_file_example)
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "config": document.config.model_dump(),
+                "instructions": document.instructions.model_dump(),
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+def _handle_config_set(args: argparse.Namespace) -> int:
+    config_service, _, _ = _build_runtime_services()
+    config = config_service.load()
+
+    if args.provider is not None:
+        config.llm.provider = args.provider
+    if args.model is not None:
+        config.llm.model = args.model
+    if args.base_url is not None:
+        config.llm.base_url = args.base_url
+    if args.temperature is not None:
+        config.llm.temperature = args.temperature
+    if args.api_key is not None:
+        config.llm.api_key = args.api_key
+    if args.project_root is not None:
+        config.repository.project_root = args.project_root
+    if args.repository_label is not None:
+        config.repository.repository_label = args.repository_label
+    if args.default_goal is not None:
+        config.repository.default_goal = args.default_goal
+
+    saved = config_service.update(config)
+    config_service.apply_to_environment(saved)
+    get_chat_model.cache_clear()
+    print(json.dumps({"config": saved.model_dump()}, indent=2, ensure_ascii=False))
+    return 0
+
+
+def _handle_sessions_list(_: argparse.Namespace) -> int:
+    _, orchestrator, _ = _build_runtime_services()
+    sessions = orchestrator.list_sessions()
+    print(
+        json.dumps(
+            [
+                {
+                    "session_id": session.session_id,
+                    "goal": session.goal,
+                    "plan": session.plan,
+                    "status": session.status,
+                    "history_length": len(session.history),
+                }
+                for session in sessions
+            ],
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+def _handle_plan_create(args: argparse.Namespace) -> int:
+    _, orchestrator, _ = _build_runtime_services()
+    session = orchestrator.create_plan(args.goal)
+    print(json.dumps(session.to_dict(), indent=2, ensure_ascii=False))
+    return 0
+
+
+def _handle_run_message(args: argparse.Namespace) -> int:
+    _, orchestrator, _ = _build_runtime_services()
+    run = orchestrator.handle_message(args.session_id, args.message)
+    print(json.dumps(run.to_dict(), indent=2, ensure_ascii=False))
+    return 0
+
+
+def _handle_execute_plan(args: argparse.Namespace) -> int:
+    _, orchestrator, _ = _build_runtime_services()
+    run = orchestrator.execute_plan(args.session_id)
+    print(json.dumps(run.to_dict(), indent=2, ensure_ascii=False))
+    return 0
+
+
+def _handle_repository_context(args: argparse.Namespace) -> int:
+    _, _, repository_service = _build_runtime_services()
+    context = repository_service.build_context(
+        query=args.query,
+        limit=max(1, min(args.limit, 25)),
+    )
+    print(json.dumps(context.to_dict(), indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/config/runtime.py
+++ b/backend/config/runtime.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from backend.llm.factory import DEFAULT_OLLAMA_BASE_URL
+
 
 DEFAULT_CONFIG_FILE_NAME = "autodev.config.json"
 
@@ -96,6 +98,7 @@ class RuntimeConfigService:
             f"OPENAI_API_KEY={active_config.llm.api_key}",
             f"OPENAI_MODEL={active_config.llm.model}",
             f"OPENAI_BASE_URL={active_config.llm.base_url}",
+            f"OLLAMA_BASE_URL={self._resolve_ollama_base_url(active_config)}",
             f"OPENAI_TEMPERATURE={active_config.llm.temperature}",
             f"AUTODEV_PROJECT_ROOT={active_config.repository.project_root}",
         ]
@@ -108,6 +111,7 @@ class RuntimeConfigService:
                 "Se preferir, copie os exemplos para .env antes de iniciar os serviços.",
                 "O diretório configurado passa a ser usado pelo endpoint de contexto de repositório e pelo Navigator agent.",
                 "LLM_PROVIDER=stub preserva um caminho totalmente local e determinístico quando não houver chave de API.",
+                "LLM_PROVIDER=ollama habilita um caminho local first-class usando a API compatível com OpenAI do Ollama.",
             ],
         )
 
@@ -117,6 +121,7 @@ class RuntimeConfigService:
         os.environ["LLM_PROVIDER"] = active_config.llm.provider
         os.environ["OPENAI_MODEL"] = active_config.llm.model
         os.environ["OPENAI_BASE_URL"] = active_config.llm.base_url
+        os.environ["OLLAMA_BASE_URL"] = self._resolve_ollama_base_url(active_config)
         os.environ["OPENAI_TEMPERATURE"] = str(active_config.llm.temperature)
         os.environ["AUTODEV_PROJECT_ROOT"] = active_config.repository.project_root
 
@@ -154,6 +159,12 @@ class RuntimeConfigService:
             normalized.repository.default_goal.strip() or "Bootstrap AutoDev project"
         )
         return normalized
+
+    def _resolve_ollama_base_url(self, config: RuntimeConfig) -> str:
+        configured_base_url = config.llm.base_url.strip()
+        if config.llm.provider == "ollama":
+            return configured_base_url or DEFAULT_OLLAMA_BASE_URL
+        return configured_base_url
 
     def _resolve_project_root(self, value: str) -> str:
         candidate = Path(value).expanduser() if value.strip() else self._default_project_root

--- a/backend/llm/factory.py
+++ b/backend/llm/factory.py
@@ -13,9 +13,13 @@ from langchain_core.outputs import ChatGeneration, ChatResult
 __all__ = [
     "LLMConfigurationError",
     "StubChatModel",
+    "DEFAULT_OLLAMA_BASE_URL",
     "get_chat_model",
     "is_configured_model",
 ]
+
+
+DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434/v1"
 
 
 class LLMConfigurationError(RuntimeError):
@@ -114,6 +118,28 @@ def get_chat_model(
             model=resolved_model,
             temperature=resolved_temperature,
             api_key=api_key,
+            base_url=base_url,
+        )
+
+    if resolved_provider == "ollama":
+        resolved_model = model or os.getenv("OPENAI_MODEL", "llama3.1")
+        resolved_temperature = (
+            temperature
+            if temperature is not None
+            else _read_temperature(os.getenv("OPENAI_TEMPERATURE"), default=0.2)
+        )
+        base_url = (
+            os.getenv("OLLAMA_BASE_URL")
+            or os.getenv("OPENAI_BASE_URL")
+            or DEFAULT_OLLAMA_BASE_URL
+        )
+
+        from langchain_openai import ChatOpenAI
+
+        return ChatOpenAI(
+            model=resolved_model,
+            temperature=resolved_temperature,
+            api_key=os.getenv("OPENAI_API_KEY") or "ollama",
             base_url=base_url,
         )
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
   "langchain-openai>=0.1.1",
 ]
 
+[project.scripts]
+autodev = "backend.cli:main"
+
 [project.optional-dependencies]
 dev = [
   "pytest>=8.0",

--- a/docs/implementation/implementation_strategy.md
+++ b/docs/implementation/implementation_strategy.md
@@ -235,3 +235,5 @@ Current functional slice in this repository:
 ## Runtime configuration slice
 
 The frontend should evolve from a chat demo into an execution control center. The current slice introduces a typed runtime configuration document persisted in `autodev.config.json`, exposed via `GET /config` and `PUT /config`, and used to configure both the active LLM provider settings and the repository/workspace root consumed by repository intelligence. This keeps operational state outside prompt text while preserving a file-based path that works for self-hosted deployments.
+
+The same runtime document is now also exposed through a structured local CLI (`python -m backend.cli` / `autodev`) so operators can inspect and update state without depending on the web UI. The 0.6 slice additionally treats `ollama` as a first-class local-model path by defaulting to an OpenAI-compatible local endpoint, preserving the project goal of remaining operable without paid inference infrastructure.

--- a/docs/implementation/self_hosting_oss.md
+++ b/docs/implementation/self_hosting_oss.md
@@ -1,0 +1,123 @@
+# OSS Self-Hosting Guide
+
+This guide documents the current self-hosting paths for AutoDev Architect using only open-source-friendly infrastructure.
+
+---
+
+## Goals of the current slice
+
+- keep the default runtime operable without paid services;
+- preserve state outside prompt text via local config and durable storage;
+- support both UI-driven and CLI-driven operator workflows;
+- offer a first-class local-model path through Ollama.
+
+---
+
+## Supported operating modes
+
+### 1. Deterministic bootstrap mode
+
+Use this mode when you want a fully local setup without any live model dependency.
+
+- `LLM_PROVIDER=stub`
+- SQLite-backed durable store
+- FastAPI backend
+- Next.js frontend
+- optional CLI via `python -m backend.cli`
+
+This is the safest initial path for contributors and CI-style smoke testing.
+
+### 2. Local-model mode with Ollama
+
+Use this mode when you want local inference without a hosted provider.
+
+- `LLM_PROVIDER=ollama`
+- `OPENAI_MODEL` or runtime config `llm.model` set to an Ollama-served model such as `llama3.1`
+- `OLLAMA_BASE_URL` defaults to `http://localhost:11434/v1`
+- the backend uses an OpenAI-compatible transport so the same typed runtime config works across providers
+
+Recommended startup flow:
+
+1. Start Ollama locally.
+2. Pull the desired model in Ollama.
+3. Save the provider/model settings through the web config workspace or the CLI.
+4. Start the backend and frontend.
+
+### 3. Hybrid hosted-provider mode
+
+Use this when a hosted model is acceptable for some environments.
+
+- `LLM_PROVIDER=openai`
+- `OPENAI_API_KEY` required
+- `OPENAI_BASE_URL` optional for compatible gateways/proxies
+
+This mode should remain optional rather than required for core platform operation.
+
+---
+
+## Runtime configuration surfaces
+
+The current repository exposes the same typed runtime state through:
+
+- `GET /config` and `PUT /config`;
+- the frontend config workspace;
+- `python -m backend.cli config show`;
+- `python -m backend.cli config set ...`.
+
+This keeps configuration explicit, reviewable, and file-backed in `autodev.config.json`.
+
+---
+
+## Local startup checklist
+
+### Backend
+
+```bash
+source .venv/bin/activate
+uvicorn backend.api.main:app --reload
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm run dev
+```
+
+### CLI examples
+
+```bash
+python -m backend.cli config show
+python -m backend.cli plan "Improve OSS self-hosting workflow"
+python -m backend.cli repository context --query "config ollama cli"
+```
+
+---
+
+## Docker Compose bootstrap
+
+The repository ships a bootstrap Compose stack in `infrastructure/docker-compose.yml`.
+
+Current characteristics:
+
+- backend runs with `LLM_PROVIDER=stub` by default;
+- frontend points to the local backend API;
+- persistent backend data is stored in the `autodev_data` volume.
+
+This keeps the default Compose story aligned with the OSS-first requirement, even before PostgreSQL/Redis/MinIO are wired into the production path.
+
+---
+
+## Known gaps before production-grade self-hosting
+
+The current 0.6 slice is intentionally incomplete. The next release wave should add:
+
+- PostgreSQL as the primary durable store;
+- Redis-backed async execution;
+- MinIO-backed artifact storage;
+- persisted multi-repository policies;
+- Docker sandbox validation;
+- OpenTelemetry, Prometheus, Grafana, and Loki integration;
+- stronger CI coverage for backend, frontend, docs, and infrastructure.
+
+These items are tracked in [`docs/roadmap.md`](../roadmap.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -100,6 +100,12 @@ Success criteria:
 
 ## Release 0.6 - OSS competitive platform
 
+Current implementation status:
+- a first OSS-competitive slice now includes a structured local CLI for config, planning, execution, and repository-context inspection;
+- runtime configuration and the web UI now expose `ollama` as a first-class local-model path through an OpenAI-compatible endpoint;
+- self-hosting guidance now documents local-only and hybrid startup paths built around the existing Docker Compose stack;
+- observability dashboards, multi-repository policies, and broader CI coverage remain the next major gaps to close.
+
 Goals:
 - local model support as first-class path
 - CLI
@@ -111,3 +117,64 @@ Goals:
 Success criteria:
 - self-hosted install succeeds with only open source dependencies
 - project becomes viable as an OSS alternative in the GenAI coding workflow space
+
+---
+
+## Release 0.7 - Governance and policy control plane
+
+Goals:
+- persisted repository policy documents
+- approval rules by run type and action category
+- command allowlists for validation/sandbox execution
+- audit events for configuration, approvals, and patch application
+- workspace/repository switching with explicit active policy selection
+
+Success criteria:
+- operators can define policy without editing prompts
+- sensitive actions are blocked or gated consistently across UI, API, and CLI
+- every approval and policy decision is auditable
+
+---
+
+## Release 0.8 - Patch execution and sandbox validation
+
+Goals:
+- unified diff artifact model
+- patch application service with rollback metadata
+- Docker sandbox validation runner
+- stored validation artifacts and logs
+- automated rework loop from validator failures back into coding tasks
+
+Success criteria:
+- the platform can produce, apply, validate, and store a reviewable patch end-to-end
+- failed validation emits structured evidence that can drive another iteration
+
+---
+
+## Release 0.9 - Observability and operations
+
+Goals:
+- OpenTelemetry instrumentation
+- Prometheus metrics for runs, agents, and validation outcomes
+- Grafana/Loki starter dashboards
+- operator-facing run diagnostics in the UI
+- CI coverage for backend, frontend, docs, and infrastructure checks
+
+Success criteria:
+- a self-hosted operator can inspect latency, failures, and throughput without prompt forensics
+- dashboards and logs make workflow regressions obvious
+
+---
+
+## Release 1.0 - Team-ready OSS platform
+
+Goals:
+- PostgreSQL + Redis production path replacing bootstrap-only storage assumptions
+- multi-repository tenancy and policy inheritance
+- role-aware approvals and artifact governance
+- documented production deployment on Docker Compose and Kubernetes
+- contributor and operator documentation for serious OSS adoption
+
+Success criteria:
+- the platform is deployable as a credible OSS alternative for real engineering teams
+- core planning, repository intelligence, patching, validation, governance, and observability flows work together in a reviewable control plane

--- a/frontend/app/config/page.tsx
+++ b/frontend/app/config/page.tsx
@@ -151,6 +151,7 @@ export default function ConfigPage() {
                   >
                     <option value="stub">stub</option>
                     <option value="openai">openai</option>
+                    <option value="ollama">ollama</option>
                   </select>
                 </label>
 
@@ -171,7 +172,7 @@ export default function ConfigPage() {
                   <span>Base URL</span>
                   <input
                     value={configDraft.llm.base_url}
-                    placeholder="Optional proxy / OpenAI-compatible gateway"
+                    placeholder="OpenAI-compatible gateway or Ollama /v1 endpoint"
                     onChange={(event) =>
                       setConfigDraft({
                         ...configDraft,

--- a/tests/backend/test_cli.py
+++ b/tests/backend/test_cli.py
@@ -1,0 +1,79 @@
+"""CLI smoke tests for the AutoDev local workflow entrypoint."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.cli import main
+from backend.persistence.database import reset_store_cache
+
+
+@pytest.fixture(autouse=True)
+def isolated_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    database_path = tmp_path / "cli.db"
+    config_path = tmp_path / "autodev.config.json"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "README.md").write_text("CLI workspace")
+
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{database_path}")
+    monkeypatch.setenv("AUTODEV_CONFIG_PATH", str(config_path))
+    monkeypatch.chdir(tmp_path)
+    reset_store_cache()
+
+    yield
+
+    reset_store_cache()
+
+
+def test_cli_can_update_config_for_ollama(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(
+        [
+            "config",
+            "set",
+            "--provider",
+            "ollama",
+            "--model",
+            "llama3.1",
+            "--project-root",
+            "workspace",
+            "--repository-label",
+            "CLI Workspace",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["config"]["llm"]["provider"] == "ollama"
+    assert payload["config"]["repository"]["repository_label"] == "CLI Workspace"
+
+
+def test_cli_can_create_plan_and_list_sessions(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["plan", "Ship CLI release slice"]) == 0
+    plan_payload = json.loads(capsys.readouterr().out)
+
+    assert plan_payload["session_id"]
+    assert plan_payload["status"] == "awaiting_input"
+
+    assert main(["sessions", "list"]) == 0
+    sessions_payload = json.loads(capsys.readouterr().out)
+
+    assert len(sessions_payload) == 1
+    assert sessions_payload[0]["session_id"] == plan_payload["session_id"]
+
+
+def test_cli_repository_context_returns_ranked_files(capsys: pytest.CaptureFixture[str]) -> None:
+    docs_dir = Path("workspace") / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "README.md").write_text("Context guide")
+
+    exit_code = main(["repository", "context", "--query", "docs readme", "--limit", "3"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["candidate_files"][0]["path"] == "workspace/docs/README.md"

--- a/tests/backend/test_config_api.py
+++ b/tests/backend/test_config_api.py
@@ -113,3 +113,31 @@ def test_update_runtime_config_persists_file_and_updates_repository_context(
     repository_payload = repository_response.json()
     assert repository_payload["root"] == str(repository_root.resolve())
     assert repository_payload["candidate_files"][0]["path"] == "docs/README.md"
+
+
+def test_update_runtime_config_supports_ollama_provider(client: TestClient) -> None:
+    response = client.put(
+        "/config",
+        json={
+            "config": {
+                "version": 1,
+                "llm": {
+                    "provider": "ollama",
+                    "model": "llama3.1",
+                    "base_url": "",
+                    "temperature": 0.1,
+                    "api_key": "",
+                },
+                "repository": {
+                    "project_root": ".",
+                    "repository_label": "Local Models",
+                    "default_goal": "Run local workflows",
+                },
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["config"]["llm"]["provider"] == "ollama"
+    assert "OLLAMA_BASE_URL=http://localhost:11434/v1" in payload["instructions"]["env_file_example"]

--- a/tests/backend/test_llm_factory.py
+++ b/tests/backend/test_llm_factory.py
@@ -1,0 +1,41 @@
+"""Tests for provider routing in the chat model factory."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from backend.llm.factory import DEFAULT_OLLAMA_BASE_URL, get_chat_model
+
+
+def test_ollama_provider_uses_local_openai_compatible_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    class FakeChatOpenAI:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setitem(sys.modules, "langchain_openai", types.SimpleNamespace(ChatOpenAI=FakeChatOpenAI))
+    get_chat_model.cache_clear()
+
+    model = get_chat_model(provider="ollama", model="llama3.1")
+
+    assert isinstance(model, FakeChatOpenAI)
+    assert calls[0]["base_url"] == DEFAULT_OLLAMA_BASE_URL
+    assert calls[0]["api_key"] == "ollama"
+    assert calls[0]["model"] == "llama3.1"
+
+
+def test_openai_provider_without_key_falls_back_to_stub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    get_chat_model.cache_clear()
+
+    model = get_chat_model(provider="openai")
+
+    assert getattr(model, "is_stub", False) is True


### PR DESCRIPTION
### Motivation
- Deliver remaining parts of the 0.6 OSS slice by adding a structured local operator surface and a first-class local-model path to make the project self-hostable without paid inference.
- Make runtime configuration and local-model defaults explicit and discoverable by UI, API, and CLI to keep operational state out of prompts.

### Description
- Add a structured CLI entrypoint `backend.cli` / `autodev` with subcommands for `config`, `plan`, `sessions`, `run`, and `repository context` to inspect and operate the system from the terminal (`backend/cli.py` and `backend/pyproject.toml`).
- Implement first-class `ollama` provider routing in `backend/llm/factory.py` with a `DEFAULT_OLLAMA_BASE_URL` and wire `OLLAMA_BASE_URL` into runtime config (`backend/config/runtime.py`) and the frontend config UI (`frontend/app/config/page.tsx`).
- Expand documentation and roadmap for release 0.6 and post-0.6 milestones, and add a self-hosting guide (`docs/implementation/self_hosting_oss.md`, `docs/roadmap.md`, `README.md`, `docs/implementation/implementation_strategy.md`, `DESCRIPTION.md`).
- Add tests covering CLI behavior, Ollama provider factory routing, and config API support (`tests/backend/test_cli.py`, `tests/backend/test_llm_factory.py`, updated `tests/backend/test_config_api.py`).

### Testing
- Ran unit/integration test suite: `pytest tests/backend/test_cli.py tests/backend/test_llm_factory.py tests/backend/test_config_api.py tests/backend/test_api.py`, all tests passed (10 passed).
- Exercised the new CLI: `python -m backend.cli config show --format env` which printed expected env variables.
- Attempted frontend dependency install with `cd frontend && npm install`, which failed in this environment due to npm registry HTTP 403; this does not affect backend tests or CLI validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff61c58bc832a9445a5a20e1ecf43)