### PR TITLE
Refine chat workspace layout: focused chat + right-side execution console

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,30 +1,23 @@
 "use client";
 
-import Link from "next/link";
 import { FormEvent, useEffect, useState } from "react";
 
 import ChatLayout from "../components/ChatLayout";
-import ExecutionPlanPanel from "../components/ExecutionPlanPanel";
+import ExecutionConsolePanel from "../components/ExecutionConsolePanel";
 import MessageList, { type Message } from "../components/MessageList";
-import PlanSidebar from "../components/PlanSidebar";
-import RunHistoryPanel from "../components/RunHistoryPanel";
 import {
   type ExecutionPlanResponse,
-  type RepositoryContextResponse,
   type RunResponse,
   type RuntimeConfig,
   type SessionResponse,
   executePlan,
   getExecutionPlan,
-  getRepositoryContext,
   getRuntimeConfig,
   listRuns,
   listSessions,
   requestPlan,
   sendChatMessage,
 } from "../lib/api";
-
-const DEFAULT_REPOSITORY_QUERY = "configuração llm repositório projeto";
 
 export default function Page() {
   return <ExecutionControlCenter />;
@@ -41,9 +34,8 @@ function ExecutionControlCenter() {
   const [config, setConfig] = useState<RuntimeConfig | null>(null);
   const [sessions, setSessions] = useState<SessionResponse[]>([]);
   const [runs, setRuns] = useState<RunResponse[]>([]);
-  const [repositoryContext, setRepositoryContext] =
-    useState<RepositoryContextResponse | null>(null);
   const [executionPlan, setExecutionPlan] = useState<ExecutionPlanResponse | null>(null);
+  const [isConsoleOpen, setIsConsoleOpen] = useState(false);
 
   useEffect(() => {
     async function bootstrap() {
@@ -68,16 +60,14 @@ function ExecutionControlCenter() {
           setMessages([
             {
               author: "Planner",
-              content: `Initial plan created for goal: ${planResponse.goal}`,
+              content: `Plano inicial criado para o objetivo: ${planResponse.goal}`,
             },
           ]);
           setSessions(await listSessions());
           setExecutionPlan(await getExecutionPlan(planResponse.session_id));
         }
-
-        setRepositoryContext(await getRepositoryContext(DEFAULT_REPOSITORY_QUERY));
       } catch {
-        setError("Failed to bootstrap the execution control center.");
+        setError("Não foi possível carregar o workspace de chat.");
       }
     }
 
@@ -86,6 +76,17 @@ function ExecutionControlCenter() {
 
   const currentWorkspaceLabel = config?.repository.repository_label;
   const currentProjectRoot = config?.repository.project_root;
+  const executionStatus = runs[0]?.status ?? executionPlan?.status ?? "awaiting_input";
+  const isBusy = isLoading || isExecutingPlan;
+  const hasConsoleEntries = runs.some((run) => run.results.length > 0);
+  const showConsole = isConsoleOpen || isBusy || hasConsoleEntries;
+  const nextTasks = executionPlan?.tasks.slice(0, 3) ?? [];
+
+  useEffect(() => {
+    if (isBusy || hasConsoleEntries) {
+      setIsConsoleOpen(true);
+    }
+  }, [hasConsoleEntries, isBusy]);
 
   async function refreshSessionState(activeSessionId: string) {
     const refreshedSessions = await listSessions();
@@ -111,7 +112,7 @@ function ExecutionControlCenter() {
       setMessages(mapHistoryToMessages(response.history));
       await refreshSessionState(sessionId);
     } catch {
-      setError("Unable to contact orchestrator API.");
+      setError("Não foi possível enviar a mensagem para o orquestrador.");
     } finally {
       setPendingMessage("");
       setIsLoading(false);
@@ -133,13 +134,14 @@ function ExecutionControlCenter() {
       setMessages([
         {
           author: "Planner",
-          content: `Initial plan created for goal: ${response.goal}`,
+          content: `Plano inicial criado para o objetivo: ${response.goal}`,
         },
       ]);
       setSessions(await listSessions());
       setExecutionPlan(await getExecutionPlan(response.session_id));
+      setIsConsoleOpen(false);
     } catch {
-      setError("Unable to create a new planning session.");
+      setError("Não foi possível criar uma nova sessão.");
     }
   }
 
@@ -156,113 +158,108 @@ function ExecutionControlCenter() {
       setMessages(mapHistoryToMessages(response.history));
       await refreshSessionState(sessionId);
     } catch {
-      setError("Unable to execute the generated plan.");
+      setError("Não foi possível executar o plano gerado.");
     } finally {
       setIsExecutingPlan(false);
     }
   }
 
   return (
-    <ChatLayout
-      currentView="dashboard"
-      sidebar={
-        <PlanSidebar
-          plan={plan}
-          sessionId={sessionId}
-          status={runs[0]?.status ?? executionPlan?.status ?? "awaiting_input"}
-          repositoryLabel={currentWorkspaceLabel}
-          projectRoot={currentProjectRoot}
-        />
-      }
-    >
-      <section className="hero-card">
-        <div>
-          <p className="eyebrow">Release 0.6 workflow slice</p>
-          <h1>AutoDev Architect control center</h1>
-          <p className="subtitle">
-            Review the current plan, derive a post-analysis execution backlog, and run each task in
-            sequence from the main dashboard.
-          </p>
-        </div>
-        <div className="hero-card__actions">
-          <Link className="secondary-button secondary-button--link" href="/config">
-            Open config workspace
-          </Link>
-          <button className="secondary-button" type="button" onClick={handleCreateSession}>
-            New planning session
-          </button>
-        </div>
-      </section>
-
-      <ExecutionPlanPanel
-        executionPlan={executionPlan}
-        isExecuting={isExecutingPlan}
-        onExecute={handleExecutePlan}
-      />
-
-      <div className="panel-grid panel-grid--two-up">
-        <section className="panel-card">
-          <div className="panel-card__header">
+    <ChatLayout currentView="dashboard" layoutMode="focus">
+      <div className={`workspace-shell ${showConsole ? "workspace-shell--with-console" : ""}`}>
+        <section className="chat-surface">
+          <header className="chat-surface__header">
             <div>
-              <p className="eyebrow">Repository intelligence</p>
-              <h2>Context preview for the active project</h2>
+              <p className="eyebrow">Sessão ativa</p>
+              <h2>Chat focado na execução</h2>
+              <p className="subtitle">
+                Uma interface mais limpa para conversar com os agentes sem o visual de dashboard.
+              </p>
             </div>
+
+            <div className="chat-surface__actions">
+              <button className="secondary-button" type="button" onClick={handleCreateSession}>
+                Nova sessão
+              </button>
+              <button
+                className="secondary-button"
+                type="button"
+                onClick={() => setIsConsoleOpen((current) => !current)}
+              >
+                {showConsole ? "Ocultar painel" : "Abrir painel"}
+              </button>
+              <button
+                type="button"
+                onClick={handleExecutePlan}
+                disabled={!executionPlan || executionPlan.tasks.length === 0 || isExecutingPlan}
+              >
+                {isExecutingPlan ? "Executando..." : "Executar plano"}
+              </button>
+            </div>
+          </header>
+
+          <div className="chat-overview">
+            <div className="chat-overview__meta">
+              <span className="status-pill">{executionStatus}</span>
+              <span className="tag">{currentWorkspaceLabel || "Workspace não configurado"}</span>
+              <span className="tag">Sessões: {sessions.length}</span>
+            </div>
+            <p className="run-card__meta">
+              Sessão: {sessionId || "não iniciada"} · Root: {currentProjectRoot || "não configurado"}
+            </p>
+            {executionPlan ? (
+              <div className="plan-preview">
+                <div className="plan-preview__header">
+                  <strong>Próximas etapas</strong>
+                  <span className="run-card__meta">{executionPlan.tasks.length} tarefas</span>
+                </div>
+                {nextTasks.length === 0 ? (
+                  <p className="empty-state">
+                    Envie uma instrução no chat para gerar um backlog executável.
+                  </p>
+                ) : (
+                  <ol className="plan-preview__list">
+                    {nextTasks.map((task) => (
+                      <li key={task.task_id}>
+                        <strong>{task.title}</strong>
+                        <span>{task.description}</span>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </div>
+            ) : null}
           </div>
 
-          {repositoryContext ? (
-            <div className="repository-context">
-              <p className="run-card__meta">
-                Root: {repositoryContext.root} · Files: {repositoryContext.total_files}
-              </p>
-              <div className="tag-list">
-                {repositoryContext.top_directories.map((directory) => (
-                  <span className="tag" key={directory}>
-                    {directory}
-                  </span>
-                ))}
-              </div>
-              <div className="candidate-list">
-                {repositoryContext.candidate_files.map((file) => (
-                  <article className="candidate-card" key={file.path}>
-                    <strong>{file.path}</strong>
-                    <p>score {file.score}</p>
-                    <p>{file.reasons.join(" · ")}</p>
-                  </article>
-                ))}
-              </div>
+          {error ? <p className="error-banner">{error}</p> : null}
+
+          <MessageList messages={messages} />
+
+          <form className="chat-composer chat-composer--clean" onSubmit={handleSubmit}>
+            <textarea
+              value={pendingMessage}
+              onChange={(event) => setPendingMessage(event.target.value)}
+              placeholder="Descreva a mudança que você quer fazer..."
+            />
+            <button type="submit" disabled={isLoading || !pendingMessage.trim()}>
+              {isLoading ? "Enviando..." : "Enviar"}
+            </button>
+          </form>
+
+          <div className="chat-plan-notes">
+            <strong>Plano atual</strong>
+            <div className="tag-list">
+              {plan.map((step, index) => (
+                <span className="tag" key={`${index}-${step}`}>
+                  {step}
+                </span>
+              ))}
             </div>
-          ) : (
-            <p className="empty-state">Loading repository context...</p>
-          )}
+          </div>
         </section>
 
-        <RunHistoryPanel runs={runs} />
+        {showConsole ? <ExecutionConsolePanel runs={runs} isBusy={isBusy} /> : null}
       </div>
-
-      <section className="panel-card">
-        <div className="panel-card__header">
-          <div>
-            <p className="eyebrow">Agent console</p>
-            <h2>Conversation and execution log</h2>
-          </div>
-          <p className="run-card__meta">Known sessions: {sessions.length}</p>
-        </div>
-
-        <MessageList messages={messages} />
-
-        <form className="chat-composer" onSubmit={handleSubmit}>
-          <textarea
-            value={pendingMessage}
-            placeholder="Describe the next action for the agents"
-            onChange={(event) => setPendingMessage(event.target.value)}
-          />
-          <button type="submit" disabled={!sessionId || isLoading}>
-            {isLoading ? "Thinking..." : "Send"}
-          </button>
-        </form>
-      </section>
-
-      {error ? <p role="alert" className="error-banner">{error}</p> : null}
     </ChatLayout>
   );
 }

--- a/frontend/components/ChatLayout.tsx
+++ b/frontend/components/ChatLayout.tsx
@@ -4,16 +4,38 @@ import Link from "next/link";
 import { ReactNode } from "react";
 
 type ChatLayoutProps = {
-  sidebar: ReactNode;
+  sidebar?: ReactNode;
   children: ReactNode;
   currentView?: "dashboard" | "config";
+  layoutMode?: "sidebar" | "focus";
 };
 
 export function ChatLayout({
   sidebar,
   children,
   currentView = "dashboard",
+  layoutMode = "sidebar",
 }: ChatLayoutProps) {
+  if (layoutMode === "focus") {
+    return (
+      <div className="chat-layout chat-layout--focus">
+        <header className="chat-topbar">
+          <div className="chat-topbar__brand">
+            <p className="eyebrow">AutoDev Architect</p>
+            <h1>Chat workspace</h1>
+          </div>
+
+          <nav className="chat-topbar__nav" aria-label="Primary">
+            <Link className="secondary-button secondary-button--link" href="/config">
+              Configuração
+            </Link>
+          </nav>
+        </header>
+        <main className="chat-layout__main">{children}</main>
+      </div>
+    );
+  }
+
   return (
     <div className="chat-layout">
       <aside className="chat-layout__sidebar">

--- a/frontend/components/ExecutionConsolePanel.tsx
+++ b/frontend/components/ExecutionConsolePanel.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import type { RunResponse } from "../lib/api";
+
+type ExecutionConsolePanelProps = {
+  runs: RunResponse[];
+  isBusy: boolean;
+};
+
+type ConsoleEntry = {
+  id: string;
+  label: string;
+  command: string;
+  output: string;
+  status: string;
+};
+
+function buildConsoleEntries(runs: RunResponse[]): ConsoleEntry[] {
+  return runs.flatMap((run) =>
+    run.results.map((result, index) => {
+      const taskTitle =
+        typeof result.metadata?.title === "string" ? result.metadata.title : result.content;
+      const taskDescription =
+        typeof result.metadata?.description === "string"
+          ? result.metadata.description
+          : result.content;
+      const category =
+        typeof result.metadata?.category === "string" ? result.metadata.category : result.agent;
+      const sourceAgent =
+        typeof result.metadata?.source_agent === "string"
+          ? result.metadata.source_agent
+          : result.agent;
+      const status =
+        typeof result.metadata?.status === "string" ? result.metadata.status : run.status;
+
+      return {
+        id: `${run.run_id}-${index}`,
+        label: run.run_type === "plan_execution" ? "Execução" : "Agente",
+        command:
+          run.run_type === "plan_execution"
+            ? `${category}: ${taskTitle}`
+            : `${sourceAgent} -> ${taskTitle}`,
+        output: taskDescription,
+        status,
+      };
+    })
+  );
+}
+
+export function ExecutionConsolePanel({ runs, isBusy }: ExecutionConsolePanelProps) {
+  const entries = buildConsoleEntries(runs);
+
+  return (
+    <aside className="execution-console" aria-live="polite">
+      <div className="execution-console__header">
+        <div>
+          <p className="eyebrow">Execução</p>
+          <h2>Painel lateral</h2>
+        </div>
+        <span className={`status-pill ${isBusy ? "status-pill--running" : ""}`}>
+          {isBusy ? "Executando" : "Pronto"}
+        </span>
+      </div>
+
+      <p className="status-text">
+        {isBusy
+          ? "Mostrando a atividade mais recente, comandos derivados e saídas registradas."
+          : "Quando houver atividade, o histórico executado aparece aqui em ordem cronológica."}
+      </p>
+
+      {entries.length === 0 ? (
+        <div className="execution-console__empty">
+          <p>Ainda não há comandos ou saídas registrados para esta sessão.</p>
+        </div>
+      ) : (
+        <div className="execution-console__stream">
+          {entries.map((entry) => (
+            <article className="console-entry" key={entry.id}>
+              <div className="console-entry__header">
+                <span className="console-entry__label">{entry.label}</span>
+                <span className="status-pill">{entry.status}</span>
+              </div>
+              <code className="console-entry__command">{entry.command}</code>
+              <pre className="console-entry__output">{entry.output}</pre>
+            </article>
+          ))}
+        </div>
+      )}
+    </aside>
+  );
+}
+
+export default ExecutionConsolePanel;

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -50,6 +50,36 @@ button:hover:not(:disabled) {
   min-height: 100vh;
 }
 
+.chat-layout--focus {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.chat-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.1rem 2rem;
+  border-bottom: 1px solid var(--border);
+  background: rgba(10, 15, 31, 0.72);
+  backdrop-filter: blur(18px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.chat-topbar__brand h1 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.chat-topbar__nav {
+  display: flex;
+  gap: 0.75rem;
+}
+
 .chat-layout__sidebar {
   background-color: rgba(10, 15, 31, 0.95);
   padding: 1.5rem;
@@ -95,6 +125,16 @@ button:hover:not(:disabled) {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.workspace-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.5rem;
+}
+
+.workspace-shell--with-console {
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
 }
 
 .sidebar-stack {
@@ -165,6 +205,65 @@ button:hover:not(:disabled) {
 .hero-card,
 .panel-card {
   padding: 1.5rem;
+}
+
+.chat-surface,
+.execution-console {
+  background: linear-gradient(180deg, rgba(18, 25, 54, 0.96), rgba(15, 21, 48, 0.96));
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.22);
+}
+
+.chat-surface {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  min-height: calc(100vh - 8.5rem);
+}
+
+.chat-surface__header,
+.execution-console__header,
+.chat-overview,
+.plan-preview__header,
+.console-entry__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.chat-surface__actions,
+.chat-overview__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.chat-overview {
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--border);
+  border-radius: 0.95rem;
+  background: rgba(15, 23, 42, 0.45);
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.plan-preview {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.plan-preview__list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.plan-preview__list li {
+  display: grid;
+  gap: 0.3rem;
 }
 
 .hero-card {
@@ -433,8 +532,10 @@ button:disabled {
 
 .message-list {
   flex: 1;
-  max-height: 420px;
+  min-height: 340px;
+  max-height: 100%;
   overflow-y: auto;
+  padding-right: 0.35rem;
 }
 
 .message__author {
@@ -448,6 +549,88 @@ button:disabled {
   margin: 0.5rem 0 0;
   white-space: pre-wrap;
   line-height: 1.6;
+}
+
+.chat-composer--clean {
+  align-items: flex-end;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+}
+
+.chat-composer--clean textarea {
+  min-height: 92px;
+  background: rgba(8, 15, 30, 0.92);
+}
+
+.chat-plan-notes {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.execution-console {
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+  align-self: start;
+  position: sticky;
+  top: 5.8rem;
+  max-height: calc(100vh - 7rem);
+  overflow: hidden;
+}
+
+.execution-console__empty,
+.execution-console__stream {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.execution-console__stream {
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.console-entry {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 0.95rem;
+  background: rgba(8, 15, 30, 0.86);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.console-entry__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.console-entry__command,
+.console-entry__output {
+  margin: 0;
+  font-family: "SFMono-Regular", ui-monospace, monospace;
+  font-size: 0.86rem;
+}
+
+.console-entry__command {
+  display: block;
+  padding: 0.8rem 0.9rem;
+  border-radius: 0.8rem;
+  background: rgba(15, 23, 42, 0.96);
+  border: 1px solid var(--border);
+  color: #bfdbfe;
+  white-space: pre-wrap;
+}
+
+.console-entry__output {
+  white-space: pre-wrap;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.status-pill--running {
+  background: rgba(52, 211, 153, 0.16);
+  border-color: rgba(52, 211, 153, 0.28);
 }
 
 .error-banner {
@@ -464,6 +647,10 @@ button:disabled {
     grid-template-columns: 1fr;
   }
 
+  .workspace-shell--with-console {
+    grid-template-columns: 1fr;
+  }
+
   .chat-layout__sidebar {
     min-height: auto;
     position: static;
@@ -475,9 +662,15 @@ button:disabled {
   .config-form__grid {
     grid-template-columns: 1fr;
   }
+
+  .execution-console {
+    position: static;
+    max-height: none;
+  }
 }
 
 @media (max-width: 720px) {
+  .chat-topbar,
   .chat-layout__main,
   .chat-layout__sidebar {
     padding: 1rem;
@@ -485,6 +678,9 @@ button:disabled {
 
   .hero-card,
   .panel-card__header,
+  .chat-surface__header,
+  .execution-console__header,
+  .console-entry__header,
   .chat-composer,
   .search-form,
   .config-form__actions,


### PR DESCRIPTION
### Motivation
- Provide a cleaner, focused chat workspace (no dashboard clutter) and surface live execution activity in a right-side panel so users can see commands and outputs while a run is executing.

### Description
- Add a `layoutMode` ("focus") to the shared `ChatLayout` and support an optional `sidebar` to enable a topbar-focused chat UI (`frontend/components/ChatLayout.tsx`).
- Replace the dashboard-heavy home view with a compact, focused chat workspace that shows session metadata, a short plan preview, and a simplified composer (`frontend/app/page.tsx`).
- Add a new right-side `ExecutionConsolePanel` that renders derived commands and outputs from runs in chronological order and exposes a visual running state (`frontend/components/ExecutionConsolePanel.tsx`).
- Update global styles to support the new focus mode and split view, including topbar, console styling, sticky behavior and responsive fallbacks (`frontend/styles/globals.css`).

### Testing
- Ran type checking with `npm run typecheck` in `frontend` and it completed successfully.
- Built the production frontend with `npm run build` and the build completed successfully.
- Ran repository checks (`git diff --check`) and no whitespace or diff-check issues were found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff7e65f18832a801c382e51e78507)